### PR TITLE
Feature/implementing node content

### DIFF
--- a/NodeEditor/NodeEditorWindow/node_content_widget.py
+++ b/NodeEditor/NodeEditorWindow/node_content_widget.py
@@ -1,0 +1,16 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QTextEdit
+
+class QDMNodeContentWidget(QWidget):
+    def __init__(self, node, parent=None):
+        super().__init__(parent)
+
+        self.initUI()
+
+    def initUI(self):
+        self.layout = QVBoxLayout()
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(self.layout)
+
+        self.widget_label = QLabel("Some Title")
+        self.layout.addWidget(self.widget_label)
+        self.layout.addWidget(QTextEdit("Some content here..."))

--- a/NodeEditor/NodeEditorWindow/node_editor_window.py
+++ b/NodeEditor/NodeEditorWindow/node_editor_window.py
@@ -1,6 +1,6 @@
-from PyQt5.QtWidgets import QGraphicsView, QWidget, QVBoxLayout, QGraphicsItem, QPushButton, QTextEdit
+from PyQt5.QtWidgets import QGraphicsView, QWidget, QVBoxLayout, QGraphicsItem, QPushButton, QTextEdit, QApplication
 from PyQt5.QtGui import QBrush, QPen, QColor, QFont
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QFile
 
 from NodeEditorWindow.node_scene import Scene
 from NodeEditorWindow.node_node import Node
@@ -9,6 +9,9 @@ from NodeEditorWindow.node_graphics_view import QDMGraphicsView
 class NodeEditorWindow(QWidget):
     def __init__(self, parent = None):
         super().__init__(parent)
+
+        self.stylesheet_filename = "NodeEditor/qss/nodestyle.qss"
+        self.loadStylesheet(self.stylesheet_filename)
 
         self.initUI()
 
@@ -32,3 +35,10 @@ class NodeEditorWindow(QWidget):
 
         self.setWindowTitle("Node Editor")
         self.show()
+
+    def loadStylesheet(self, filename):
+        import inspect, os; print('>', os.path.basename(inspect.stack()[0].filename), '-', inspect.stack()[0].lineno, " filename: ", filename)
+        file = QFile(filename)
+        file.open(QFile.OpenModeFlag.ReadOnly | QFile.OpenModeFlag.Text)
+        stylesheet = file.readAll()
+        QApplication.instance().setStyleSheet(str(stylesheet, encoding='utf-8'))

--- a/NodeEditor/NodeEditorWindow/node_graphics_node.py
+++ b/NodeEditor/NodeEditorWindow/node_graphics_node.py
@@ -3,8 +3,9 @@ from PyQt5.QtCore import Qt, QRectF
 from PyQt5.QtGui import QFont, QPainterPath, QPen, QColor, QBrush
 
 class QDMGraphicsNode(QGraphicsItem):
-    def __init__(self, node, title="Node Graphics Item", parent=None):
+    def __init__(self, node, parent=None):
         super().__init__(parent)
+        self.node = node
 
         self._title_color = Qt.GlobalColor.white
         self._title_font = QFont("Arial")
@@ -21,7 +22,7 @@ class QDMGraphicsNode(QGraphicsItem):
         self._brush_background = QBrush(QColor("#E3212121"))
 
         self.initTitle()
-        self.title = title
+        self.title = self.node.title
         self.initUI()
 
     def boundingRect(self):

--- a/NodeEditor/NodeEditorWindow/node_graphics_node.py
+++ b/NodeEditor/NodeEditorWindow/node_graphics_node.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QGraphicsItem, QGraphicsTextItem
+from PyQt5.QtWidgets import QGraphicsItem, QGraphicsTextItem, QGraphicsProxyWidget
 from PyQt5.QtCore import Qt, QRectF
 from PyQt5.QtGui import QFont, QPainterPath, QPen, QColor, QBrush
 
@@ -6,6 +6,7 @@ class QDMGraphicsNode(QGraphicsItem):
     def __init__(self, node, parent=None):
         super().__init__(parent)
         self.node = node
+        self.content = self.node.content
 
         self._title_color = Qt.GlobalColor.white
         self._title_font = QFont("Arial")
@@ -21,9 +22,23 @@ class QDMGraphicsNode(QGraphicsItem):
         self._brush_title = QBrush(QColor("#FF313131"))
         self._brush_background = QBrush(QColor("#E3212121"))
 
+        # init title
         self.initTitle()
         self.title = self.node.title
+
+        # init sockets
+
+        # init content
+        self.initContent()
+
         self.initUI()
+
+    @property
+    def title(self): return self._title
+    @title.setter
+    def title(self, value):
+        self._title = value
+        self.title_item.setPlainText(value)
 
     def boundingRect(self):
         return QRectF(0, 0, self.width, self.height).normalized()
@@ -39,12 +54,15 @@ class QDMGraphicsNode(QGraphicsItem):
         self.title_item.setPos(self._padding, 0)
         self.title_item.setTextWidth(self.width -2 * self._padding)
 
-    @property
-    def title(self): return self._title
-    @title.setter
-    def title(self, value):
-        self._title = value
-        self.title_item.setPlainText(value)
+    def initContent(self):
+        self.graphicsContents = QGraphicsProxyWidget(self)
+        self.content.setGeometry(
+            int(self.edge_size),
+            int(self.title_height + self.edge_size),
+            int(self.width - 2 * self.edge_size),
+            int(self.height - 2 * self.edge_size - self.title_height)
+        )
+        self.graphicsContents.setWidget(self.content)
 
     def paint(self, painter, QStyleOptionGraphicsItem, widget = None):
         # title

--- a/NodeEditor/NodeEditorWindow/node_node.py
+++ b/NodeEditor/NodeEditorWindow/node_node.py
@@ -5,7 +5,7 @@ class Node():
         self.scene = scene
         self.title = title
 
-        self.graphicsNode = QDMGraphicsNode(self, self.title)
+        self.graphicsNode = QDMGraphicsNode(self)
 
         self.scene.addNode(self)
         self.scene.graphicsScene.addItem(self.graphicsNode)

--- a/NodeEditor/NodeEditorWindow/node_node.py
+++ b/NodeEditor/NodeEditorWindow/node_node.py
@@ -1,10 +1,12 @@
 from NodeEditorWindow.node_graphics_node import QDMGraphicsNode
+from NodeEditorWindow.node_content_widget import QDMNodeContentWidget
 
 class Node():
     def __init__(self, scene, title = "Undefined Node"):
         self.scene = scene
         self.title = title
 
+        self.content = QDMNodeContentWidget(self)
         self.graphicsNode = QDMGraphicsNode(self)
 
         self.scene.addNode(self)

--- a/NodeEditor/qss/nodestyle.qss
+++ b/NodeEditor/qss/nodestyle.qss
@@ -1,0 +1,6 @@
+QDMNodeContentWidget {
+    background-color: transparent;
+}
+QDMNodeContentWidget QLabel {
+    color: #e0e0e0;
+}


### PR DESCRIPTION
## 📌 Feature 6: Integrated Node Content Widget and Stylesheet Support

### Summary
This pull request introduces the `QDMNodeContentWidget` class for managing node content and links it to the node system via a clean Model/View separation. It also adds support for external QSS stylesheets to control the appearance of node widgets.

---

### 📁 Files Changed / Added

- `node_node.py`  
  - Removed the `title` argument when creating `QDMGraphicsNode`  
  - Added `self.content = QDMNodeContentWidget(self)` to initialize the content widget  

- `node_graphics_node.py`  
  - Removed `title` parameter; now accesses `self.node.title` directly  
  - Added `initContent()` method that embeds the node content using `QGraphicsProxyWidget`  

- `node_editor_window.py`  
  - Added stylesheet loading logic:  
    ```python
    self.stylesheet_filename = "NodeEditor/qss/nodestyle.qss"
    self.loadStylesheet(self.stylesheet_filename)
    ```

- `node_content_widget.py` (🆕 New File)  
  - Contains the `QDMNodeContentWidget`, a `QWidget` that includes a `QLabel` and `QTextEdit`

- `qss/nodestyle.qss` (🆕 New File)  
  - Basic style customization for node content area and text color

---

### ✏️ Directory Structure Overview

```
NodeEditor/
├── NodeEditorWindow/
│   ├── node_node.py
│   ├── node_graphics_node.py
│   ├── node_content_widget.py     ← 🆕 Added
│   └── node_editor_window.py
├── qss/
│   └── nodestyle.qss              ← 🆕 Added
└── node_editor_main.py
```

---

### ✅ Features Implemented

| Feature                                               | Status |
|--------------------------------------------------------|--------|
| Removed redundant title passing to graphics node       | ✅     |
| Introduced `QDMNodeContentWidget`                     | ✅     |
| Embedded QWidget into QGraphicsItem via ProxyWidget    | ✅     |
| Loaded external QSS stylesheet for content customization | ✅     |
| Supports QLabel + QTextEdit layout inside the node     | ✅     |

---

### 🔍 Preview

Run `node_editor_main.py` to see:

- Nodes with title bars and embedded content widgets
- A label and text editor area styled with a dark theme
- Node appearance is automatically styled via the `nodestyle.qss` file

```bash
python node_editor_main.py
```

---

### 📌 Motivation

These changes are foundational for future features:

- Custom node inputs (e.g., checkboxes, dropdowns, controls)
- Saving and restoring user input inside nodes
- Consistent appearance using centralized styling

This enhances modularity and separation of concerns in the UI system.
