### PR TITLE
Feature/create dragging edge

### DIFF
--- a/node_editor/node_editor_window/core/edge.py
+++ b/node_editor/node_editor_window/core/edge.py
@@ -36,6 +36,8 @@ class Edge():
             end_pos[0] += self.end_socket.node.graphicsNode.pos().x()
             end_pos[1] += self.end_socket.node.graphicsNode.pos().y()
             self.graphicsEdge.setDestination(*end_pos)
+        else:
+            self.graphicsEdge.setDestination(*source_pos)
         self.graphicsEdge.update()
 
     def remove_from_socket(self):

--- a/node_editor/node_editor_window/core/edge.py
+++ b/node_editor/node_editor_window/core/edge.py
@@ -21,6 +21,10 @@ class Edge():
         self.updatePositions()
         logger.debug(f" Edge: {self.graphicsEdge.posSource} to {self.graphicsEdge.posDestination}")
         self.scene.graphicsScene.addItem(self.graphicsEdge)
+        self.scene.addEdge(self)
+
+    def __str__(self):
+        return "< Edge %s ... %s >" % (hex(id(self))[2:5], hex(id(self))[-3:])
 
     def updatePositions(self):
         source_pos = self.start_socket.getSocketPosition()

--- a/node_editor/node_editor_window/core/node.py
+++ b/node_editor/node_editor_window/core/node.py
@@ -33,6 +33,9 @@ class Node():
             counter += 1
             self.outputs.append(socket)
 
+    def __str__(self):
+        return "< Node %s ... %s >" % (hex(id(self))[2:5], hex(id(self))[-3:]) + " Title: %s" % self.title
+
     @property
     def pos(self):
         return self.graphicsNode.setPos()       # QPonintF

--- a/node_editor/node_editor_window/core/socket.py
+++ b/node_editor/node_editor_window/core/socket.py
@@ -16,12 +16,15 @@ class Socket():
         self.position = position
         self.socket_type = socket_type
 
-        self.graphicsSocket = QDMGraphicsSocket(self.node.graphicsNode, self.socket_type)
+        self.graphicsSocket = QDMGraphicsSocket(self, self.socket_type)
         self.graphicsSocket.setPos(*self.node.setSocketPosition(self.index, self.position))
 
         logger.debug(f"Socket -- creating with {self.index} {self.position} for node {self.node}")
 
         self.edge = None
+
+    def __str__(self):
+        return "< Socket %s ... %s >" % (hex(id(self))[2:5], hex(id(self))[-3:])
 
     def getSocketPosition(self):
         logger.debug(f"Get socket position: {self.index} {self.position} for node {self.node}")

--- a/node_editor/node_editor_window/graphics/graphics_edge.py
+++ b/node_editor/node_editor_window/graphics/graphics_edge.py
@@ -11,8 +11,11 @@ class QDMGraphicsEdge(QGraphicsPathItem):
         self._color_selected = QColor("#00FF00")
         self._pen = QPen(self._color)
         self._pen_selected = QPen(self._color_selected)
+        self._pen_dragging = QPen(self._color)
+        self._pen_dragging.setStyle(Qt.PenStyle.DashLine)
         self._pen.setWidthF(2)
         self._pen_selected.setWidthF(2)
+        self._pen_dragging.setWidthF(2)
 
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable)
 
@@ -30,7 +33,10 @@ class QDMGraphicsEdge(QGraphicsPathItem):
     def paint(self, painter: QPainter, QStyleOptionGraphicsItem, widget = None):
         self.updatePath()
 
-        painter.setPen(self._pen if not self.isSelected() else self._pen_selected)
+        if self.edge.end_socket is None:
+            painter.setPen(self._pen_dragging)
+        else:
+            painter.setPen(self._pen if not self.isSelected() else self._pen_selected)
         painter.setBrush(Qt.BrushStyle.NoBrush)
         painter.drawPath(self.path())
 

--- a/node_editor/node_editor_window/graphics/graphics_edge.py
+++ b/node_editor/node_editor_window/graphics/graphics_edge.py
@@ -1,6 +1,11 @@
+import math
 from PyQt5.QtWidgets import QGraphicsPathItem, QGraphicsItem
 from PyQt5.QtGui import QPainter, QPen, QColor, QPainterPath
 from PyQt5.QtCore import Qt, QPointF
+
+from node_editor_window.core.socket import RIGHT_BOTTOM, RIGHT_TOP, LEFT_BOTTOM, LEFT_TOP
+
+EDGE_CP_ROUNDNESS = 100
 
 class QDMGraphicsEdge(QGraphicsPathItem):
     def __init__(self, edge, parent=None):
@@ -55,8 +60,28 @@ class QDMGraphicsEdgeBezier(QDMGraphicsEdge):
         s = self.posSource
         d = self.posDestination
         dist = (d[0] - s[0]) * 0.5
-        if s[0] > d[0]: dist *= -1
+        cpx_s = +dist
+        cpx_d = -dist
+        cpy_s = 0
+        cpy_d = 0
+
+        sspos = self.edge.start_socket.position
+
+        if (s[0] > d[0] and sspos in (RIGHT_TOP, RIGHT_BOTTOM)) or (s[0] < d[0] and sspos in (LEFT_BOTTOM, LEFT_TOP)):
+            cpx_d *= -1
+            cpx_s *= -1
+
+            cpy_d = (
+                (s[1] - d[1]) / math.fabs(
+                    (s[1] - d[1]) if (s[1] - d[1]) != 0 else 0.00001
+                )
+            ) * EDGE_CP_ROUNDNESS
+            cpy_s = (
+                (d[1] - s[1]) / math.fabs(
+                    (d[1] - s[1]) if (d[1] - s[1]) != 0 else 0.00001
+                )
+            ) * EDGE_CP_ROUNDNESS
 
         path = QPainterPath(QPointF(self.posSource[0], self.posSource[1]))
-        path.cubicTo( s[0] + dist, s[1], d[0] - dist, d[1], self.posDestination[0], self.posDestination[1])
+        path.cubicTo( s[0] + cpx_s, s[1] + cpy_s, d[0] + cpx_d, d[1] + cpy_d, self.posDestination[0], self.posDestination[1])
         self.setPath(path)

--- a/node_editor/node_editor_window/graphics/graphics_socket.py
+++ b/node_editor/node_editor_window/graphics/graphics_socket.py
@@ -3,8 +3,9 @@ from PyQt5.QtGui import QColor, QPen, QPainter
 from PyQt5.QtCore import QRectF
 
 class QDMGraphicsSocket(QGraphicsItem):
-    def __init__(self, parent = None, socket_type:int = 1):
-        super().__init__(parent)
+    def __init__(self, socket, socket_type:int = 1):
+        self.socket = socket
+        super().__init__(socket.node.graphicsNode)
 
         self.radius = 6.0
         self.outline_width = 1.0

--- a/node_editor/node_editor_window/graphics/graphics_view.py
+++ b/node_editor/node_editor_window/graphics/graphics_view.py
@@ -155,6 +155,8 @@ class QDMGraphicsView(QGraphicsView):
     def edgeDragStart(self, item):
         logger.debug("Start dragging edge")
         logger.debug(f"    assign Start Socket to: {item.socket}")
+        self.previousEdge = item.socket.edge
+        self.last_start_socket = item.socket
         self.dragEdge = Edge(self.graphicsScene.scene, item.socket, None, EDGE_TYPE_BEZIER)
         logger.debug(f"    dragEdge: {self.dragEdge}")
     
@@ -164,16 +166,22 @@ class QDMGraphicsView(QGraphicsView):
 
         if isinstance(item, QDMGraphicsSocket):
             logger.debug(f"    assign End Socket to: {item.socket}")
+            if self.previousEdge is not None: self.previousEdge.remove()
+            logger.debug("    previous edge removed")
+            self.dragEdge.start_socket = self.last_start_socket
             self.dragEdge.end_socket = item.socket
             self.dragEdge.start_socket.setConnectedEdge(self.dragEdge)
             self.dragEdge.end_socket.setConnectedEdge(self.dragEdge)
-            logger.debug(f"    assigned start and end sockets to drag edge")
+            logger.debug(f"    reassigned start and end sockets to drag edge")
             self.dragEdge.updatePositions()
             return True
         
         logger.debug("End dragging edge")
         self.dragEdge.remove()
         self.dragEdge = None
+        logger.debug(f"about to set socket to previous edge: {self.previousEdge}")
+        if self.previousEdge is None:
+            self.previousEdge.start_socket.edge = self.previousEdge
         logger.debug("everything done.")
         return False
     

--- a/node_editor/node_editor_window/graphics/graphics_view.py
+++ b/node_editor/node_editor_window/graphics/graphics_view.py
@@ -165,6 +165,9 @@ class QDMGraphicsView(QGraphicsView):
         self.mode = MODE_NOOP
 
         if isinstance(item, QDMGraphicsSocket):
+            logger.debug(f"    ~, previous edge: {self.previousEdge}")
+            if item.socket.hasEdge():
+                item.socket.edge.remove()
             logger.debug(f"    assign End Socket to: {item.socket}")
             if self.previousEdge is not None: self.previousEdge.remove()
             logger.debug("    previous edge removed")
@@ -180,7 +183,7 @@ class QDMGraphicsView(QGraphicsView):
         self.dragEdge.remove()
         self.dragEdge = None
         logger.debug(f"about to set socket to previous edge: {self.previousEdge}")
-        if self.previousEdge is None:
+        if self.previousEdge is not None:
             self.previousEdge.start_socket.edge = self.previousEdge
         logger.debug("everything done.")
         return False

--- a/node_editor/node_editor_window/graphics/graphics_view.py
+++ b/node_editor/node_editor_window/graphics/graphics_view.py
@@ -6,6 +6,7 @@ from PyQt5.QtGui import QPainter, QMouseEvent
 from PyQt5.QtCore import Qt, QEvent
 
 from node_editor_window.graphics.graphics_socket import QDMGraphicsSocket
+from node_editor_window.graphics.graphics_edge import QDMGraphicsEdge
 
 MODE_NOOP = 1
 MODE_EDGE_DRAG = 2
@@ -119,6 +120,20 @@ class QDMGraphicsView(QGraphicsView):
 
     def rightMouseButtonPress(self, event):
         super().mousePressEvent(event)
+
+        item = self.getItemAtClick(event)
+        if isinstance(item, QDMGraphicsEdge): logger.debug(f"RBM DBUG: {item.edge} connecting sockets: {item.edge.start_socket} <--> {item.edge.end_socket}")
+        if isinstance(item, QDMGraphicsSocket): logger.debug(f"RBM DEBUG: {item.socket} has edge {item.socket.edge}")
+
+        if item is None:
+            logger.debug(f"SCENE: {self.graphicsScene}")
+            logger.debug("    NODE:")
+            for node in self.graphicsScene.scene.nodes:
+                logger.debug(f"        {node}")
+            logger.debug("    EDGE:")
+            for edge in self.graphicsScene.scene.edges:
+                logger.debug(f"        {edge}") 
+            return
 
     def rightMouseButtonRelease(self, event):
         super().mouseReleaseEvent(event)


### PR DESCRIPTION
## 🌐 Feature 12: Enhanced Edge Dragging, Visual Feedback, and Debug Support

### Summary

This pull request significantly enhances the edge dragging experience in the node editor with improved visuals, logic, and debug support:

- Added `__str__` methods to `Node`, `Socket`, and `Edge` for clearer debugging output  
- Introduced dashed line style for visual feedback when dragging an unconnected edge  
- Improved Bezier control point calculations for smoother edge curves  
- Properly handles previous edges when reconnecting during drag  
- Refactored socket/graphics socket construction to provide full context  
- Added logging in RMB interaction and drag logic for better traceability  

---

### 📁 Files Added / Modified

| File                           | Description                                                                 |
|--------------------------------|-----------------------------------------------------------------------------|
| `core/node.py`                | Added `__str__` method, improved edge destination fallback logic            |
| `core/socket.py`              | Added `__str__` method, updated graphics socket creation logic              |
| `core/edge.py`                | Added `__str__` method                                                      |
| `graphics/graphics_edge.py`  | Added dashed style for dragging, refined Bezier control point calculation   |
| `graphics/graphics_socket.py`| Modified constructor to receive `Socket` and derive parent from node        |
| `graphics/graphics_view.py`  | Enhanced edge dragging logic, added debug output, proper edge reconnection  |

---

### ✅ Features Implemented

| Feature                                                             | Status |
|---------------------------------------------------------------------|--------|
| Dashed visual for dragging edge when end socket not yet assigned    | ✅     |
| Bezier edge control points adjust based on socket layout direction  | ✅     |
| Proper removal of previous edge when reconnecting                   | ✅     |
| String representation for Node, Edge, and Socket                    | ✅     |
| `QDMGraphicsSocket` constructor accepts socket reference            | ✅     |
| Right mouse button logs detailed socket/edge/node structure         | ✅     |
| Live edge position updates while dragging with mouse move           | ✅     |

---

### ⚙️ Example Logging Output

```python
logger.debug("Start dragging edge")
logger.debug("    assign Start Socket to: < Socket abc ... 123 >")
logger.debug("    dragEdge: < Edge 456 ... def >")

logger.debug("    ~, previous edge: < Edge 111 ... 222 >")
logger.debug("    assign End Socket to: < Socket 333 ... 444 >")
logger.debug("    previous edge removed")
logger.debug("    reassigned start and end sockets to drag edge")
```

Right-click on edge or socket now logs their current state:

```python
RBM DEBUG: < Edge 456 ... def > connecting sockets: < Socket abc ... 123 > <--> < Socket 333 ... 444 >
RBM DEBUG: < Socket abc ... 123 > has edge < Edge 456 ... def >
```

---

### 🎨 Edge Visual Enhancements

Dragging edges (no end socket yet) now show a dashed visual line:

```python
self._pen_dragging = QPen(self._color)
self._pen_dragging.setStyle(Qt.PenStyle.DashLine)
self._pen_dragging.setWidthF(2)
```

Used in `paint()` if `edge.end_socket is None`:

```python
if self.edge.end_socket is None:
    painter.setPen(self._pen_dragging)
else:
    painter.setPen(self._pen if not self.isSelected() else self._pen_selected)
```
---

### 🖱️ Interaction Behavior

- Edge follows the mouse in real-time (`mouseMoveEvent`)  
- If dragged to a valid socket, a new edge is created, old ones removed if needed  
- If dropped elsewhere, edge is discarded and previous edge restored  

---

### 🗂️ Relevant Folder Structure

```plaintext
core/
├── node.py                # ✅ Added __str__, fallback destination logic
├── socket.py              # ✅ Added __str__, updated graphics socket usage
├── edge.py                # ✅ Added __str__

graphics/
├── graphics_edge.py       # ✅ Dashed line + curve refinement
├── graphics_socket.py     # ✅ Socket reference passed to graphics socket
├── graphics_view.py       # ✅ Edge drag logic overhaul + debug logging
```

---

### 📌 Related Commits

- Added string representation of edges and sockets, and adjusted the initialization parameters of QDMGraphicsSocket  
- Improve the edge drag logic, add a new dashed line style when dragging, and adjust the related drawing and update logic  
- Improved edge drag logic, added previous edge processing, and adjusted the connection logic of start and end sockets  
- Improved control point calculation for Bezier curve edges, adjusting the Y offset of control points based on start and end socket positions  
- Corrected edge dragging logic to ensure previous edge is removed correctly when assigning end socket  
