### PR TITLE
Feature/implement selecting items

### DIFF
--- a/node_editor/node_editor_window/graphics/graphics_node.py
+++ b/node_editor/node_editor_window/graphics/graphics_node.py
@@ -36,7 +36,10 @@ class QDMGraphicsNode(QGraphicsItem):
 
     def mouseMoveEvent(self, event):
         super().mouseMoveEvent(event)
-        self.node.updateConnectedEdges()
+
+        for node in self.scene().scene.nodes:
+            if node.graphicsNode.isSelected():
+                node.updateConnectedEdges()
 
     @property
     def title(self): return self._title
@@ -54,6 +57,7 @@ class QDMGraphicsNode(QGraphicsItem):
 
     def initTitle(self):
         self.title_item = QGraphicsTextItem(self)
+        self.title_item.node = self.node
         self.title_item.setDefaultTextColor(self._title_color)
         self.title_item.setFont(self._title_font)
         self.title_item.setPos(self._padding, 0)

--- a/node_editor/node_editor_window/qss/nodestyle.qss
+++ b/node_editor/node_editor_window/qss/nodestyle.qss
@@ -4,3 +4,6 @@ QDMNodeContentWidget {
 QDMNodeContentWidget QLabel {
     color: #e0e0e0;
 }
+QGraphicsView {
+    selection-background-color: rgb(255, 255, 255);
+}


### PR DESCRIPTION
## 🌐 Feature 13: Improved Node Selection Drag, Edge Updates, and Modifier-based Click Handling

### Summary

This pull request enhances interaction behavior in the node editor, focusing on mouse drag, selection updates, and modifier-aware click processing:

- Nodes now live-update their connected edges while being moved  
- Middle and left mouse button logic refined for modifier keys  
- Improves multi-selection experience using Shift + Click  
- Graphics view now has better styling and selection drag support  
- Adds utility logging method to debug modifier keys during events  

---

### 📁 Files Added / Modified

| File                                          | Description                                                                 |
|-----------------------------------------------|-----------------------------------------------------------------------------|
| `graphics/graphics_node.py`                   | Updates edge connections during move, binds `node` to `title_item`         |
| `graphics/graphics_view.py`                   | Adds modifier-aware LMB logic, debug logging, and enables drag selection   |
| `qss/nodestyle.qss`                           | Adds base style for `QGraphicsView`                                        |

---

### ✅ Features Implemented

| Feature                                                             | Status |
|---------------------------------------------------------------------|--------|
| Live edge updates while moving selected nodes                      | ✅     |
| Shift+Click enables additive selection behavior                    | ✅     |
| Added logging to inspect active modifier keys during events        | ✅     |
| Selection rubber-band enabled in `QGraphicsView`                   | ✅     |
| Binds `QGraphicsTextItem` to parent `node` for easier access       | ✅     |

---

### ⚙️ Example Logging Output

```python
logger.debug(f"LMB Click on item: {item} - {self.debug_modifiers(event)}")
```
Sample output during interactions:
```plaintext
LMB Click on item: <QDMGraphicsNode ...> - KEYS: SHIFT CTRL 
```

---

### 🖱️ Interaction Behavior

* Dragging Selected Nodes: All connected edges automatically update on mouse move
* Shift + Click on `Nod`e or `Edge`: Adds/removes item from selection without breaking others
* Selection Rubber Band: Enabled with `QGraphicsView.DragMode.RubberBandDrag`
* Title Handling: `QGraphicsTextItem` now carries a `.node` reference for easier access

---

### 🎨 UI Enhancements

Added default selection background styling to `QGraphicsView`:
```css
QGraphicsView {
    selection-background-color: rgb(255, 255, 255);
}
```

---

### 🗂️ Relevant Folder Structure
```plaintext
node_editor/node_editor_window/
├── graphics/
│   ├── graphics_node.py       # ✅ Update connections, bind title item to node
│   ├── graphics_view.py       # ✅ Modifier-aware LMB, drag mode, logging
├── qss/
│   └── nodestyle.qss          # ✅ Added QGraphicsView base style
```

---

### 📌 Related Commits

* Updated `mouseMoveEvent` to trigger `updateConnectedEdges()` on selected nodes
* Added Shift+Click processing in `leftMouseButtonPress` and `leftMouseButtonRelease`
* Bound `QGraphicsTextItem` title to node instance for later retrieval
* Added `debug_modifiers()` helper to show active keyboard modifiers
* Enabled selection rubber band and added `QGraphicsView` style override
