### PR TITLE
Feature/implementing deleting items

### DIFF
--- a/node_editor/node_editor_window/content/node_content_widget.py
+++ b/node_editor/node_editor_window/content/node_content_widget.py
@@ -1,7 +1,11 @@
+import logging
+logger = logging.getLogger(__name__)
+
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QTextEdit
 
 class QDMNodeContentWidget(QWidget):
     def __init__(self, node, parent=None):
+        self.node = node
         super().__init__(parent)
 
         self.initUI()
@@ -13,4 +17,16 @@ class QDMNodeContentWidget(QWidget):
 
         self.widget_label = QLabel("Some Title")
         self.layout.addWidget(self.widget_label)
-        self.layout.addWidget(QTextEdit("Some content here..."))
+        self.layout.addWidget(QDMTextEdit("Some content here..."))
+
+    def setEditingFlag(self, value):
+        self.node.scene.graphicsScene.views()[0].editingFlag = value
+
+class QDMTextEdit(QTextEdit):
+    def focusInEvent(self, event):
+        self.parentWidget().setEditingFlag(True)
+        super().focusInEvent(event)
+    
+    def focusOutEvent(self, event):
+        self.parentWidget().setEditingFlag(False)
+        super().focusOutEvent(event)

--- a/node_editor/node_editor_window/core/edge.py
+++ b/node_editor/node_editor_window/core/edge.py
@@ -19,7 +19,6 @@ class Edge():
         self.graphicsEdge = QDMGraphicsEdgeDirect(self) if edge_type == EDGE_TYPE_DIRECT else QDMGraphicsEdgeBezier(self)
 
         self.updatePositions()
-        logger.debug(f" Edge: {self.graphicsEdge.posSource} to {self.graphicsEdge.posDestination}")
         self.scene.graphicsScene.addItem(self.graphicsEdge)
         self.scene.addEdge(self)
 
@@ -49,7 +48,15 @@ class Edge():
         self.end_socket = None
 
     def remove(self):
+        logger.debug(f"> Remove Edge {self}")
+        logger.debug(f" - remove edge from all sockets")
         self.remove_from_socket()
+        logger.debug(f" - remove graphicsEdge")
         self.scene.graphicsScene.removeItem(self.graphicsEdge)
         self.graphicsEdge = None
-        self.scene.removeEdge(self)
+        logger.debug(f" - remove edge from scene")
+        try:
+            self.scene.removeEdge(self)
+        except ValueError:
+            pass
+        logger.debug(f" - everythings was done.")

--- a/node_editor/node_editor_window/core/node.py
+++ b/node_editor/node_editor_window/core/node.py
@@ -1,4 +1,6 @@
 from typing import List
+import logging
+logger = logging.getLogger(__name__)
 
 from node_editor_window.graphics.graphics_node import QDMGraphicsNode
 from node_editor_window.content.node_content_widget import QDMNodeContentWidget
@@ -61,3 +63,17 @@ class Node():
         for socket in self.inputs + self.outputs:
             if socket.hasEdge():
                 socket.edge.updatePositions()
+
+    def remove(self):
+        logger.debug(f"> Remove Node {self}")
+        logger.debug(f" - remove all edge from sockets")
+        for socket in (self.inputs + self.outputs):
+            if socket.hasEdge():
+                logger.debug(f"     - removing from socket: {socket} edge {socket.edge}")
+                socket.edge.remove()
+        logger.debug(f" - remove graphicsNode")
+        self.scene.graphicsScene.removeItem(self.graphicsNode)
+        self.graphicsNode = None
+        logger.debug(f" - remove node from scene")
+        self.scene.removeNode(self)
+        logger.debug(f" - everythings was done.")

--- a/node_editor/node_editor_window/graphics/graphics_view.py
+++ b/node_editor/node_editor_window/graphics/graphics_view.py
@@ -2,7 +2,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from PyQt5.QtWidgets import QGraphicsView
-from PyQt5.QtGui import QPainter, QMouseEvent
+from PyQt5.QtGui import QPainter, QMouseEvent, QKeyEvent
 from PyQt5.QtCore import Qt, QEvent
 
 from node_editor_window.core.edge import Edge, EDGE_TYPE_BEZIER
@@ -175,6 +175,19 @@ class QDMGraphicsView(QGraphicsView):
             self.dragEdge.graphicsEdge.setDestination(pos.x(), pos.y())
             self.dragEdge.graphicsEdge.update()
         super().mouseMoveEvent(event)
+
+    def keyPressEvent(self, event: QKeyEvent):
+        if event.key() == Qt.Key.Key_Delete:
+            self.deleteSelected()
+        else:
+            super().keyPressEvent(event)
+
+    def deleteSelected(self):
+        for item in self.graphicsScene.selectedItems():
+            if isinstance(item, QDMGraphicsEdge):
+                item.edge.remove()
+            elif hasattr(item, "node"):
+                item.node.remove()
 
     def debug_modifiers(self, event):
         out = "KEYS: "

--- a/node_editor/node_editor_window/graphics/graphics_view.py
+++ b/node_editor/node_editor_window/graphics/graphics_view.py
@@ -202,19 +202,20 @@ class QDMGraphicsView(QGraphicsView):
         self.mode = MODE_NOOP
 
         if isinstance(item, QDMGraphicsSocket):
-            logger.debug(f"    ~, previous edge: {self.previousEdge}")
-            if item.socket.hasEdge():
-                item.socket.edge.remove()
-            logger.debug(f"    assign End Socket to: {item.socket}")
-            if self.previousEdge is not None: self.previousEdge.remove()
-            logger.debug("    previous edge removed")
-            self.dragEdge.start_socket = self.last_start_socket
-            self.dragEdge.end_socket = item.socket
-            self.dragEdge.start_socket.setConnectedEdge(self.dragEdge)
-            self.dragEdge.end_socket.setConnectedEdge(self.dragEdge)
-            logger.debug(f"    reassigned start and end sockets to drag edge")
-            self.dragEdge.updatePositions()
-            return True
+            if item.socket != self.last_start_socket:
+                logger.debug(f"    ~, previous edge: {self.previousEdge}")
+                if item.socket.hasEdge():
+                    item.socket.edge.remove()
+                logger.debug(f"    assign End Socket to: {item.socket}")
+                if self.previousEdge is not None: self.previousEdge.remove()
+                logger.debug("    previous edge removed")
+                self.dragEdge.start_socket = self.last_start_socket
+                self.dragEdge.end_socket = item.socket
+                self.dragEdge.start_socket.setConnectedEdge(self.dragEdge)
+                self.dragEdge.end_socket.setConnectedEdge(self.dragEdge)
+                logger.debug(f"    reassigned start and end sockets to drag edge")
+                self.dragEdge.updatePositions()
+                return True
         
         logger.debug("End dragging edge")
         self.dragEdge.remove()

--- a/node_editor/node_editor_window/graphics/graphics_view.py
+++ b/node_editor/node_editor_window/graphics/graphics_view.py
@@ -25,6 +25,7 @@ class QDMGraphicsView(QGraphicsView):
         self.setScene(self.graphicsScene)
 
         self.mode = MODE_NOOP
+        self.editingFlag = False
 
         self.zoomInFator = 1.25
         self.zoomClamp = False
@@ -178,7 +179,10 @@ class QDMGraphicsView(QGraphicsView):
 
     def keyPressEvent(self, event: QKeyEvent):
         if event.key() == Qt.Key.Key_Delete:
-            self.deleteSelected()
+            if not self.editingFlag:
+                self.deleteSelected()
+            else: 
+                super().keyPressEvent(event)
         else:
             super().keyPressEvent(event)
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -31,13 +31,14 @@ if not any(isinstance(h, logging.StreamHandler) for h in root_logger.handlers):
 if file_handler and not any(isinstance(h, logging.FileHandler) for h in root_logger.handlers):
     root_logger.addHandler(file_handler)
 
+logging.getLogger("node_editor_window.content.node_content_widget").setLevel(logging.DEBUG)
 logging.getLogger("node_editor_window.core.edge").setLevel(logging.INFO)
-logging.getLogger("node_editor_window.core.node").setLevel(logging.DEBUG)
+logging.getLogger("node_editor_window.core.node").setLevel(logging.INFO)
 logging.getLogger("node_editor_window.core.scene").setLevel(logging.INFO)
 logging.getLogger("node_editor_window.core.socket").setLevel(logging.INFO)
 logging.getLogger("node_editor_window.graphics.graphics_edge").setLevel(logging.INFO)
 logging.getLogger("node_editor_window.graphics.graphics_node").setLevel(logging.INFO)
 logging.getLogger("node_editor_window.graphics.graphics_scene").setLevel(logging.INFO)
 logging.getLogger("node_editor_window.graphics.graphics_socket").setLevel(logging.INFO)
-logging.getLogger("node_editor_window.graphics.graphics_view").setLevel(logging.DEBUG)
+logging.getLogger("node_editor_window.graphics.graphics_view").setLevel(logging.INFO)
 logging.getLogger("node_editor_window.ui.node_editor_window").setLevel(logging.INFO)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -32,7 +32,7 @@ if file_handler and not any(isinstance(h, logging.FileHandler) for h in root_log
     root_logger.addHandler(file_handler)
 
 logging.getLogger("node_editor_window.core.edge").setLevel(logging.INFO)
-logging.getLogger("node_editor_window.core.node").setLevel(logging.INFO)
+logging.getLogger("node_editor_window.core.node").setLevel(logging.DEBUG)
 logging.getLogger("node_editor_window.core.scene").setLevel(logging.INFO)
 logging.getLogger("node_editor_window.core.socket").setLevel(logging.INFO)
 logging.getLogger("node_editor_window.graphics.graphics_edge").setLevel(logging.INFO)


### PR DESCRIPTION
## 🌐 Feature 14: Deletion Support, Edit Mode Control, and Edge Dragging Fixes

### Summary

This pull request introduces robust deletion support, refines edge reconnection logic, and improves input field edit-state control to avoid accidental node deletion while editing.

- Prevents reconnecting edges to the same socket during drag  
- Adds `Delete` key support to remove selected edges and nodes  
- Improves logging during edge and node removal  
- Introduces `editingFlag` to distinguish between view interaction and text editing  
- Adds `QDMTextEdit` with focus event tracking to toggle edit state  
- Refactors `QDMNodeContentWidget` to use new editable text widget  

---

### 📁 Files Added / Modified

| File                                         | Description                                                                 |
|----------------------------------------------|-----------------------------------------------------------------------------|
| `graphics/graphics_view.py`                 | Prevents self-socket reconnection, adds delete key + edit flag handling    |
| `core/node.py`                              | Adds `remove()` method with detailed logging                               |
| `core/edge.py`                              | Adds `remove()` method with detailed logging and exception safety          |
| `graphics/node_content_widget.py`           | Adds `QDMTextEdit` to track edit focus and modifies content widget usage   |

---

### ✅ Features Implemented

| Feature                                                             | Status |
|---------------------------------------------------------------------|--------|
| Prevent reconnection to the same socket during edge drag           | ✅     |
| Support Delete key to remove selected edges/nodes                  | ✅     |
| Detailed logging of edge/node removal process                      | ✅     |
| `editingFlag` to suppress Delete behavior while editing            | ✅     |
| Custom `QDMTextEdit` triggers focus events to update flag          | ✅     |
| Node content widget refactored to use editable text box            | ✅     |

---

### ⚙️ Example Logging Output

```python
> Remove Node <Node X>
 - remove all edge from sockets
     - removing from socket: <Socket Y> edge <Edge Z>
 - remove graphicsNode
 - remove node from scene
 - everythings was done.

> Remove Edge <Edge A>
 - remove edge from all sockets
 - remove graphicsEdge
 - remove edge from scene
 - everythings was done.
```

---

## 🖱️ Interaction Behavior

* Edge Drag Fix: Prevents connecting an edge back to its own start socket
* Delete Key: Deletes selected nodes or edges, except when text editing
* Edit Field Protection: Focus-aware editingFlag disables accidental deletion
* QDMTextEdit: Tracks focus in/out and notifies parent widget to toggle editing state

---

## 🗂️ Relevant Folder Structure

```
node_editor/node_editor_window/
├── core/
│   ├── node.py                 # ✅ Added full removal logic and logging
│   ├── edge.py                 # ✅ Enhanced remove method with safe handling
├── graphics/
│   ├── graphics_view.py        # ✅ Edge drag fix, delete key, editing flag
│   ├── node_content_widget.py  # ✅ Added QDMTextEdit, updated UI
```

---

## 📌 Related Commits

1. Added condition in `edgeDragEnd` to skip reconnecting if target socket is the same as the start socket
2. Increased logging to improve edge and node removal process, and added the ability to delete selected items in the graph view
3. Added new edit flags to improve the edit state management of the node content widget, and adjusted the log level to enhance debugging information