### PR TITLE
Feature/cutting edges

### DIFF
--- a/node_editor/node_editor_window/graphics/graphics_cutline.py
+++ b/node_editor/node_editor_window/graphics/graphics_cutline.py
@@ -1,0 +1,26 @@
+from PyQt5.QtWidgets import QGraphicsItem
+from PyQt5.QtGui import QPen, QPainter, QPolygonF
+from PyQt5.QtCore import Qt, QRectF
+
+class QDMCutLine(QGraphicsItem):
+    def __init__(self, parent = None):
+        super().__init__(parent)
+
+        self.line_points = []
+
+        self._pen = QPen(Qt.GlobalColor.white)
+        self._pen.setWidth(2)
+        self._pen.setDashPattern([3, 3])
+
+        self.setZValue(2)
+
+    def boundRect(self):
+        return QRectF(0, 0, 0, 1)
+    
+    def paint(self, painter: QPainter, QStyleOptionGraphicsItem, widget=None):
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.setPen(self._pen)
+
+        poly = QPolygonF(self.line_points)
+        painter.drawPolyline(poly)

--- a/node_editor/node_editor_window/graphics/graphics_cutline.py
+++ b/node_editor/node_editor_window/graphics/graphics_cutline.py
@@ -14,8 +14,8 @@ class QDMCutLine(QGraphicsItem):
 
         self.setZValue(2)
 
-    def boundRect(self):
-        return QRectF(0, 0, 0, 1)
+    def boundingRect(self):
+        return QRectF(0, 0, 1, 1)
     
     def paint(self, painter: QPainter, QStyleOptionGraphicsItem, widget=None):
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)

--- a/node_editor/node_editor_window/graphics/graphics_edge.py
+++ b/node_editor/node_editor_window/graphics/graphics_edge.py
@@ -36,7 +36,7 @@ class QDMGraphicsEdge(QGraphicsPathItem):
         self.posDestination = [x, y]
 
     def paint(self, painter: QPainter, QStyleOptionGraphicsItem, widget = None):
-        self.updatePath()
+        self.setPath(self.calcPath())
 
         if self.edge.end_socket is None:
             painter.setPen(self._pen_dragging)
@@ -45,18 +45,24 @@ class QDMGraphicsEdge(QGraphicsPathItem):
         painter.setBrush(Qt.BrushStyle.NoBrush)
         painter.drawPath(self.path())
 
-    def updatePath(self):
+    def intersectsWith(self, p1, p2):
+        cutpath = QPainterPath(p1)
+        cutpath.lineTo(p2)
+        path = self.calcPath()
+        return cutpath.intersects(path)
+
+    def calcPath(self):
         # Will handle drawing QPaintPath from A to B
         raise NotImplementedError("This method should be overriden in a child class.")
     
 class QDMGraphicsEdgeDirect(QDMGraphicsEdge):
-    def updatePath(self):
+    def calcPath(self):
         path = QPainterPath(QPointF(self.posSource[0], self.posSource[1]))
         path.lineTo(self.posDestination[0], self.posDestination[1])
-        self.setPath(path)
+        return path
 
 class QDMGraphicsEdgeBezier(QDMGraphicsEdge):
-    def updatePath(self):
+    def calcPath(self):
         s = self.posSource
         d = self.posDestination
         dist = (d[0] - s[0]) * 0.5
@@ -84,4 +90,5 @@ class QDMGraphicsEdgeBezier(QDMGraphicsEdge):
 
         path = QPainterPath(QPointF(self.posSource[0], self.posSource[1]))
         path.cubicTo( s[0] + cpx_s, s[1] + cpy_s, d[0] + cpx_d, d[1] + cpy_d, self.posDestination[0], self.posDestination[1])
-        self.setPath(path)
+        
+        return path

--- a/node_editor/node_editor_window/graphics/graphics_view.py
+++ b/node_editor/node_editor_window/graphics/graphics_view.py
@@ -221,7 +221,13 @@ class QDMGraphicsView(QGraphicsView):
             super().keyPressEvent(event)
 
     def cutIntersectingEdges(self, event):
-        pass
+        for ix in range(len(self.cutline.line_points) - 1):
+            p1 = self.cutline.line_points[ix]
+            p2 = self.cutline.line_points[ix + 1]
+
+            for edge in self.graphicsScene.scene.edges:
+                if edge.graphicsEdge.intersectsWith(p1, p2):
+                    edge.remove()
 
     def deleteSelected(self):
         for item in self.graphicsScene.selectedItems():

--- a/node_editor/node_editor_window/graphics/graphics_view.py
+++ b/node_editor/node_editor_window/graphics/graphics_view.py
@@ -1,16 +1,18 @@
 import logging
 logger = logging.getLogger(__name__)
 
-from PyQt5.QtWidgets import QGraphicsView
+from PyQt5.QtWidgets import QGraphicsView, QApplication
 from PyQt5.QtGui import QPainter, QMouseEvent, QKeyEvent
 from PyQt5.QtCore import Qt, QEvent
 
 from node_editor_window.core.edge import Edge, EDGE_TYPE_BEZIER
+from node_editor_window.graphics.graphics_cutline import QDMCutLine
 from node_editor_window.graphics.graphics_socket import QDMGraphicsSocket
 from node_editor_window.graphics.graphics_edge import QDMGraphicsEdge
 
 MODE_NOOP = 1
 MODE_EDGE_DRAG = 2
+MODE_EDGE_CUT = 3
 
 EDGE_DRAG_START_THRESHOLD = 10
 
@@ -32,6 +34,10 @@ class QDMGraphicsView(QGraphicsView):
         self.zoom = 5
         self.zoomStep = 1
         self.zoomRange = [0, 10]
+
+        # cutline
+        self.cutline = QDMCutLine()
+        self.graphicsScene.addItem(self.cutline)
 
     def initUI(self):
         self.setRenderHints(QPainter.RenderHint.Antialiasing |
@@ -122,6 +128,20 @@ class QDMGraphicsView(QGraphicsView):
         if self.mode == MODE_EDGE_DRAG:
             res = self.edgeDragEnd(item)
             if res: return
+
+        if item is None:
+            if event.modifiers() & Qt.KeyboardModifier.ControlModifier:
+                self.mode = MODE_EDGE_CUT
+                fakeEvent = QMouseEvent(
+                    QEvent.Type.MouseButtonRelease,
+                    event.localPos(),
+                    event.screenPos(),
+                    Qt.MouseButton.LeftButton,
+                    Qt.MouseButton.NoButton,
+                    event.modifiers()
+                )
+                QApplication.setOverrideCursor(Qt.CursorShape.CrossCursor)
+                return 
             
         super().mousePressEvent(event)
 
@@ -147,6 +167,14 @@ class QDMGraphicsView(QGraphicsView):
             if self.destanceBetweenClickAndReleaseOff(event):
                 res = self.edgeDragEnd(item)
                 if res: return
+
+        if self.mode == MODE_EDGE_CUT:
+            self.cutIntersectingEdges(event)
+            self.cutline.line_points = []
+            self.cutline.update()
+            QApplication.setOverrideCursor(Qt.CursorShape.ArrowCursor)
+            self.mode = MODE_NOOP
+            return 
 
         super().mouseReleaseEvent(event)
 
@@ -175,6 +203,12 @@ class QDMGraphicsView(QGraphicsView):
             pos = self.mapToScene(event.pos())
             self.dragEdge.graphicsEdge.setDestination(pos.x(), pos.y())
             self.dragEdge.graphicsEdge.update()
+
+        if self.mode == MODE_EDGE_CUT:
+            pos = self.mapToScene(event.pos())
+            self.cutline.line_points.append(pos)
+            self.cutline.update()
+
         super().mouseMoveEvent(event)
 
     def keyPressEvent(self, event: QKeyEvent):
@@ -185,6 +219,9 @@ class QDMGraphicsView(QGraphicsView):
                 super().keyPressEvent(event)
         else:
             super().keyPressEvent(event)
+
+    def cutIntersectingEdges(self, event):
+        pass
 
     def deleteSelected(self):
         for item in self.graphicsScene.selectedItems():


### PR DESCRIPTION
## ✂️ Feature 15: Edge Cutting Mode with QDMCutLine

### Summary

This pull request introduces a new "cut mode" feature that allows users to delete multiple edges by drawing a line across them. It adds the `QDMCutLine` visual, integrates edge-intersection detection, and cleanly separates edge path logic.

- Added new `QDMCutLine` class to render cutting lines  
- Introduced edge cut mode with `Ctrl + Drag` interaction  
- Added `intersectsWith()` method to edges for cutline collision detection  
- Refactored edge classes to expose `calcPath()` method for intersection checks  
- Fixed a typo in `QDMCutLine.boundingRect()` to enable proper painting  

---

### 📁 Files Added / Modified

| File                                 | Description                                                                 |
|--------------------------------------|-----------------------------------------------------------------------------|
| `graphics/graphics_cutline.py`       | ✅ New class for dashed line drawing, supports cutline visualization       |
| `graphics/graphics_view.py`          | ✅ Adds edge cut mode, handles mouse + Ctrl interaction logic              |
| `graphics/graphics_edge.py`          | ✅ Adds `intersectsWith()`, refactors path logic to `calcPath()`           |

---

### ✅ Features Implemented

| Feature                                                              | Status |
|----------------------------------------------------------------------|--------|
| QDMCutLine visual class for dashed edge-cutting path                | ✅     |
| Ctrl + Drag to activate edge cut mode                               | ✅     |
| Deletes all edges intersected by the drawn cut line                 | ✅     |
| Separated `calcPath()` from `updatePath()` for reusable edge paths  | ✅     |
| Proper `boundingRect()` implemented for custom graphics item        | ✅     |

---

### 🖱️ Interaction Behavior

- Hold **Ctrl** and drag with **Left Mouse Button** to start edge-cut mode  
- A white dashed line follows the cursor and tracks drag path  
- On release, any edges intersected by the path are **automatically removed**  
- Cursor switches to crosshair in cut mode for visual clarity  

---

### ✨ Visual Logic Example

```python
# Edge intersection check
def intersectsWith(self, p1, p2):
    cutpath = QPainterPath(p1)
    cutpath.lineTo(p2)
    path = self.calcPath()
    return cutpath.intersects(path)
```

---

## 🎨 Edge Cut Line Style

```python
self._pen = QPen(Qt.GlobalColor.white)
self._pen.setWidth(2)
self._pen.setDashPattern([3, 3])
```

---

## 🗂️ Relevant Folder Structure
```
node_editor/node_editor_window/
├── graphics/
│   ├── graphics_edge.py         # ✅ Refactor for intersection support
│   ├── graphics_view.py         # ✅ Edge cut mode (Ctrl+Drag), intersects logic
│   ├── graphics_cutline.py      # ✅ New dashed line item
```

---

## 📌 Related Commits
1. Added `QDMCutLine` class to support edge cutting and integrated cutting logic into `QDMGraphicsView`
2. Corrected the `boundingRect` method name of `QDMCutLine` and implemented the function of cutting intersecting edges in `QDMGraphicsView`
