### PR TITLE
Feature/introduction to serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 
 # Manim generated media
 media/
+
+# Save
+saves/

--- a/node_editor/node_editor_window/content/node_content_widget.py
+++ b/node_editor/node_editor_window/content/node_content_widget.py
@@ -1,9 +1,12 @@
 import logging
 logger = logging.getLogger(__name__)
+from collections import OrderedDict
 
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QTextEdit
 
-class QDMNodeContentWidget(QWidget):
+from ..serialization.serialzable import Serializable
+
+class QDMNodeContentWidget(QWidget, Serializable):
     def __init__(self, node, parent=None):
         self.node = node
         super().__init__(parent)
@@ -21,6 +24,13 @@ class QDMNodeContentWidget(QWidget):
 
     def setEditingFlag(self, value):
         self.node.scene.graphicsScene.views()[0].editingFlag = value
+
+    def serialize(self):
+        return OrderedDict([
+        ])
+    
+    def deserialize(self, data, hashmap={}):
+        return False
 
 class QDMTextEdit(QTextEdit):
     def focusInEvent(self, event):

--- a/node_editor/node_editor_window/core/edge.py
+++ b/node_editor/node_editor_window/core/edge.py
@@ -1,7 +1,7 @@
 import logging
 logger = logging.getLogger(__name__)
 
-from node_editor_window.graphics.graphics_edge import QDMGraphicsEdgeDirect, QDMGraphicsEdgeBezier
+from ..graphics.graphics_edge import QDMGraphicsEdgeDirect, QDMGraphicsEdgeBezier
 
 EDGE_TYPE_DIRECT = 1
 EDGE_TYPE_BEZIER = 2

--- a/node_editor/node_editor_window/core/edge.py
+++ b/node_editor/node_editor_window/core/edge.py
@@ -1,16 +1,21 @@
 import logging
 logger = logging.getLogger(__name__)
+from collections import OrderedDict
 
 from ..graphics.graphics_edge import QDMGraphicsEdgeDirect, QDMGraphicsEdgeBezier
+from ..serialization.serialzable import Serializable
 
 EDGE_TYPE_DIRECT = 1
 EDGE_TYPE_BEZIER = 2
 
-class Edge():
+class Edge(Serializable):
     def __init__(self, scene, start_socket, end_socket, edge_type:int = EDGE_TYPE_BEZIER):
+        super().__init__()
+        
         self.scene = scene
         self.start_socket = start_socket
         self.end_socket = end_socket
+        self.edge_type = edge_type
 
         self.start_socket.edge = self
         if self.end_socket is not None:
@@ -60,3 +65,14 @@ class Edge():
         except ValueError:
             pass
         logger.debug(f" - everythings was done.")
+
+    def serialize(self):
+        return OrderedDict([
+            ('id', self.id),
+            ('edge_type', self.edge_type),
+            ('start', self.start_socket.id),
+            ('end', self.end_socket.id)
+        ])
+    
+    def deserialize(self, data, hashmap={}):
+        return False

--- a/node_editor/node_editor_window/core/node.py
+++ b/node_editor/node_editor_window/core/node.py
@@ -2,9 +2,9 @@ from typing import List
 import logging
 logger = logging.getLogger(__name__)
 
-from node_editor_window.graphics.graphics_node import QDMGraphicsNode
-from node_editor_window.content.node_content_widget import QDMNodeContentWidget
-from node_editor_window.core.socket import Socket, LEFT_TOP, RIGHT_TOP, LEFT_BOTTOM, RIGHT_BOTTOM
+from ..graphics.graphics_node import QDMGraphicsNode
+from ..content.node_content_widget import QDMNodeContentWidget
+from .socket import Socket, LEFT_TOP, RIGHT_TOP, LEFT_BOTTOM, RIGHT_BOTTOM
 
 class Node():
     def __init__(self, scene, title:str = "Undefined Node", inputs:List = [], outputs:List = []):

--- a/node_editor/node_editor_window/core/node.py
+++ b/node_editor/node_editor_window/core/node.py
@@ -1,13 +1,17 @@
 from typing import List
 import logging
 logger = logging.getLogger(__name__)
+from collections import OrderedDict
 
+from .socket import Socket, LEFT_TOP, RIGHT_TOP, LEFT_BOTTOM, RIGHT_BOTTOM
 from ..graphics.graphics_node import QDMGraphicsNode
 from ..content.node_content_widget import QDMNodeContentWidget
-from .socket import Socket, LEFT_TOP, RIGHT_TOP, LEFT_BOTTOM, RIGHT_BOTTOM
+from ..serialization.serialzable import Serializable
 
-class Node():
+class Node(Serializable):
     def __init__(self, scene, title:str = "Undefined Node", inputs:List = [], outputs:List = []):
+        super().__init__()
+        
         self.scene = scene
         self.title = title
 
@@ -77,3 +81,20 @@ class Node():
         logger.debug(f" - remove node from scene")
         self.scene.removeNode(self)
         logger.debug(f" - everythings was done.")
+
+    def serialize(self):
+        inputs, outputs = [], []
+        for socket in self.inputs: inputs.append(socket.serialize())
+        for socket in self.outputs: outputs.append(socket.serialize())
+        return OrderedDict([
+            ('id', self.id),
+            ('title', self.title),
+            ('pos_x', self.graphicsNode.scenePos().x()),
+            ('pos_y', self.graphicsNode.scenePos().y()),
+            ('inputs', inputs),
+            ('outputs', outputs),
+            ('content', self.content.serialize())
+        ])
+    
+    def deserialize(self, data, hashmap={}):
+        return False

--- a/node_editor/node_editor_window/core/scene.py
+++ b/node_editor/node_editor_window/core/scene.py
@@ -1,4 +1,4 @@
-from node_editor_window.graphics.graphics_scene import QDMGraphicsScene
+from ..graphics.graphics_scene import QDMGraphicsScene
 
 class Scene:
     def __init__(self):

--- a/node_editor/node_editor_window/core/scene.py
+++ b/node_editor/node_editor_window/core/scene.py
@@ -1,7 +1,14 @@
-from ..graphics.graphics_scene import QDMGraphicsScene
+import json
+import logging
+logger = logging.getLogger(__name__)
+from collections import OrderedDict
 
-class Scene:
+from ..graphics.graphics_scene import QDMGraphicsScene
+from ..serialization.serialzable import Serializable
+
+class Scene(Serializable):
     def __init__(self):
+        super().__init__()
         self.nodes = []
         self.edges = []
 
@@ -27,3 +34,25 @@ class Scene:
     def removeEdge(self, edge):
         if edge in self.edges:
             self.edges.remove(edge)
+
+    def saveToFile(self, filename):
+        with open(filename, 'w') as file:
+            file.write(json.dumps(self.serialize(), indent=4))
+        logger.debug(f"saving to {filename} was successful")
+
+    def loadFromFile(self, filename):
+        with open(filename, 'r') as file:
+            raw_data = file.read()
+            data = json.loads(raw_data, encoding='utf-8')
+            self.deserialize(data)
+
+    def serialize(self):
+        return OrderedDict([
+            ('id', self.id),
+            ('scene_width', self.scene_width),
+            ('scene_height', self.scene_height),
+        ])
+    
+    def deserialize(self, data, hashmap={}):
+        logger.debug(f"deserializating data: {data}")
+        return False

--- a/node_editor/node_editor_window/core/scene.py
+++ b/node_editor/node_editor_window/core/scene.py
@@ -47,10 +47,15 @@ class Scene(Serializable):
             self.deserialize(data)
 
     def serialize(self):
+        nodes, edges = [], []
+        for node in self.nodes: nodes.append(node.serialize())
+        for edge in self.edges: edges.append(edge.serialize())
         return OrderedDict([
             ('id', self.id),
             ('scene_width', self.scene_width),
             ('scene_height', self.scene_height),
+            ('nodes', nodes),
+            ('edges', edges),
         ])
     
     def deserialize(self, data, hashmap={}):

--- a/node_editor/node_editor_window/core/socket.py
+++ b/node_editor/node_editor_window/core/socket.py
@@ -1,15 +1,18 @@
 import logging
 logger = logging.getLogger(__name__)
+from collections import OrderedDict
 
 from ..graphics.graphics_socket import QDMGraphicsSocket
+from ..serialization.serialzable import Serializable
 
 LEFT_TOP = 1
 LEFT_BOTTOM = 2
 RIGHT_TOP = 3 
 RIGHT_BOTTOM = 4
 
-class Socket():
+class Socket(Serializable):
     def __init__(self, node, index:int = 0, position:int = LEFT_TOP, socket_type:int = 1):
+        super().__init__()
 
         self.node = node
         self.index = index
@@ -37,3 +40,14 @@ class Socket():
 
     def hasEdge(self):
         return self.edge is not None
+    
+    def serialize(self):
+        return OrderedDict([
+            ('id', self.id),
+            ('index', self.index),
+            ('position', self.position),
+            ('socket_type', self.socket_type),
+        ])
+    
+    def deserialize(self, data, hashmap={}):
+        return False

--- a/node_editor/node_editor_window/core/socket.py
+++ b/node_editor/node_editor_window/core/socket.py
@@ -1,7 +1,7 @@
 import logging
 logger = logging.getLogger(__name__)
 
-from node_editor_window.graphics.graphics_socket import QDMGraphicsSocket
+from ..graphics.graphics_socket import QDMGraphicsSocket
 
 LEFT_TOP = 1
 LEFT_BOTTOM = 2

--- a/node_editor/node_editor_window/graphics/graphics_edge.py
+++ b/node_editor/node_editor_window/graphics/graphics_edge.py
@@ -3,7 +3,7 @@ from PyQt5.QtWidgets import QGraphicsPathItem, QGraphicsItem
 from PyQt5.QtGui import QPainter, QPen, QColor, QPainterPath
 from PyQt5.QtCore import Qt, QPointF
 
-from node_editor_window.core.socket import RIGHT_BOTTOM, RIGHT_TOP, LEFT_BOTTOM, LEFT_TOP
+from ..core.socket import RIGHT_BOTTOM, RIGHT_TOP, LEFT_BOTTOM, LEFT_TOP
 
 EDGE_CP_ROUNDNESS = 100
 

--- a/node_editor/node_editor_window/graphics/graphics_view.py
+++ b/node_editor/node_editor_window/graphics/graphics_view.py
@@ -1,3 +1,5 @@
+
+import os
 import logging
 logger = logging.getLogger(__name__)
 
@@ -212,11 +214,18 @@ class QDMGraphicsView(QGraphicsView):
         super().mouseMoveEvent(event)
 
     def keyPressEvent(self, event: QKeyEvent):
+        save_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "saves", "graph.json")
+        )
         if event.key() == Qt.Key.Key_Delete:
             if not self.editingFlag:
                 self.deleteSelected()
             else: 
                 super().keyPressEvent(event)
+        elif event.key() == Qt.Key.Key_S and event.modifiers() & Qt.KeyboardModifier.ControlModifier:
+            self.graphicsScene.scene.saveToFile(save_path)
+        elif event.key() == Qt.Key.Key_L and event.modifiers() & Qt.KeyboardModifier.ControlModifier:
+            self.graphicsScene.scene.loadFromFile(save_path)
         else:
             super().keyPressEvent(event)
 

--- a/node_editor/node_editor_window/graphics/graphics_view.py
+++ b/node_editor/node_editor_window/graphics/graphics_view.py
@@ -5,10 +5,10 @@ from PyQt5.QtWidgets import QGraphicsView, QApplication
 from PyQt5.QtGui import QPainter, QMouseEvent, QKeyEvent
 from PyQt5.QtCore import Qt, QEvent
 
-from node_editor_window.core.edge import Edge, EDGE_TYPE_BEZIER
-from node_editor_window.graphics.graphics_cutline import QDMCutLine
-from node_editor_window.graphics.graphics_socket import QDMGraphicsSocket
-from node_editor_window.graphics.graphics_edge import QDMGraphicsEdge
+from ..core.edge import Edge, EDGE_TYPE_BEZIER
+from ..graphics.graphics_cutline import QDMCutLine
+from ..graphics.graphics_socket import QDMGraphicsSocket
+from ..graphics.graphics_edge import QDMGraphicsEdge
 
 MODE_NOOP = 1
 MODE_EDGE_DRAG = 2

--- a/node_editor/node_editor_window/serialization/serialzable.py
+++ b/node_editor/node_editor_window/serialization/serialzable.py
@@ -1,0 +1,9 @@
+class Serializable():
+    def __init__(self):
+        self.id = id(self)
+
+    def serialize(self):
+        raise NotImplemented()
+    
+    def deserialize(self, data, hashmap={}):
+        raise NotImplemented()

--- a/node_editor/node_editor_window/ui/node_editor_window.py
+++ b/node_editor/node_editor_window/ui/node_editor_window.py
@@ -4,10 +4,10 @@ logger = logging.getLogger(__name__)
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QApplication
 from PyQt5.QtCore import QFile
 
-from node_editor_window.core.scene import Scene
-from node_editor_window.core.node import Node
-from node_editor_window.core.edge import Edge, EDGE_TYPE_BEZIER
-from node_editor_window.graphics.graphics_view import QDMGraphicsView
+from ..core.scene import Scene
+from ..core.node import Node
+from ..core.edge import Edge, EDGE_TYPE_BEZIER
+from ..graphics.graphics_view import QDMGraphicsView
 
 class NodeEditorWindow(QWidget):
     def __init__(self, parent = None):

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -34,7 +34,7 @@ if file_handler and not any(isinstance(h, logging.FileHandler) for h in root_log
 logging.getLogger("node_editor_window.content.node_content_widget").setLevel(logging.DEBUG)
 logging.getLogger("node_editor_window.core.edge").setLevel(logging.INFO)
 logging.getLogger("node_editor_window.core.node").setLevel(logging.INFO)
-logging.getLogger("node_editor_window.core.scene").setLevel(logging.INFO)
+logging.getLogger("node_editor_window.core.scene").setLevel(logging.DEBUG)
 logging.getLogger("node_editor_window.core.socket").setLevel(logging.INFO)
 logging.getLogger("node_editor_window.graphics.graphics_edge").setLevel(logging.INFO)
 logging.getLogger("node_editor_window.graphics.graphics_node").setLevel(logging.INFO)


### PR DESCRIPTION
## 🌐 Feature 16: Serialization - Saving Scene

### 📌 Summary

This pull request introduces the initial serialization framework for the node editor, enabling saving of the entire scene to disk. It includes foundational logic for serializing `Scene`, `Node`, `Socket`, `Edge`, and `QDMNodeContentWidget` using an abstract `Serializable` base class.

---

### 📁 Files Added / Modified

| File                                       | Description                                                                 |
|--------------------------------------------|-----------------------------------------------------------------------------|
| `core/scene.py`                            | Added `saveToFile`, `loadFromFile`, `serialize`, and `deserialize` methods |
| `core/node.py`                             | Implemented node serialization logic                                       |
| `core/edge.py`                             | Implemented edge serialization logic                                       |
| `core/socket.py`                           | Implemented socket serialization logic                                     |
| `node_content_widget.py`                   | Added `serialize`/`deserialize` methods                                    |
| `graphics/graphics_view.py`                | Bound Ctrl+S / Ctrl+L to save/load scene                                   |
| `serialization/serialzable.py`            | Added new `Serializable` base class                                        |
| `ui/node_editor_window.py` and all `core/` | Unified all imports using relative import syntax                           |

---

### ✅ Features Implemented

| Feature                                      | Status |
|----------------------------------------------|--------|
| Added `Serializable` abstract base class     | ✅     |
| `Scene.saveToFile()` and `loadFromFile()`    | ✅     |
| `Scene.serialize()` includes nodes and edges | ✅     |
| Serialization logic for Node, Socket, Edge   | ✅     |
| `QDMNodeContentWidget` supports serialization| ✅     |
| Keyboard shortcut `Ctrl+S` to save           | ✅     |
| Keyboard shortcut `Ctrl+L` to load           | ✅     |
| Relative imports across all core modules     | ✅     |

---

### 🧪 Example Save Path Logic (from `graphics_view.py`)

```python
save_path = os.path.abspath(
    os.path.join(os.path.dirname(__file__), "..", "..", "saves", "graph.json")
)

elif event.key() == Qt.Key.Key_S and event.modifiers() & Qt.KeyboardModifier.ControlModifier:
    self.graphicsScene.scene.saveToFile(save_path)

elif event.key() == Qt.Key.Key_L and event.modifiers() & Qt.KeyboardModifier.ControlModifier:
    self.graphicsScene.scene.loadFromFile(save_path)
```

---

## 🧱 Serializable Base Class
```python
# serialization/serialzable.py
class Serializable():
    def __init__(self):
        self.id = id(self)

    def serialize(self):
        raise NotImplemented()
    
    def deserialize(self, data, hashmap={}):
        raise NotImplemented()
```

---

## 🧠 Scene Serialization Output Example
```json
{
  "id": 139830174938112,
  "scene_width": 6400,
  "scene_height": 4800,
  "nodes": [ ... ],
  "edges": [ ... ]
}
```

---

## 🗂️ Related Commits

* Modify the import path and use relative import method uniformly
* Added serialization functionality to the Scene class, implemented save and load methods, and adjusted the log level for easier debugging
* Added serialization functionality to core classes, including QDMNodeContentWidget, Edge, Node, Scene, and Socket, and implemented serialize and deserialize methods