### PR TITLE
Bugfixing/bugfixing crashes and missing edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Official tutorial website is under development and will provide:
 *  `v0.2.0` ：  🔁 Advanced logic, edge types, and serialization
   
 ### 📦 Current Version
-**`v0.2.0.dev8`** – Under active development  
+**`v0.2.0.dev9`** – Under active development  
 
 ## 📄 License
 [MIT License](./LICENSE)

--- a/node_editor/node_editor_window/__init__.py
+++ b/node_editor/node_editor_window/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.0.dev8"
+__version__ = "0.2.0.dev9"

--- a/node_editor/node_editor_window/graphics/graphics_cutline.py
+++ b/node_editor/node_editor_window/graphics/graphics_cutline.py
@@ -1,6 +1,9 @@
+import logging
+logger = logging.getLogger(__name__)
+
 from PyQt5.QtWidgets import QGraphicsItem
-from PyQt5.QtGui import QPen, QPainter, QPolygonF
-from PyQt5.QtCore import Qt, QRectF
+from PyQt5.QtGui import QPen, QPainter, QPolygonF, QPainterPath
+from PyQt5.QtCore import Qt, QPointF
 
 class QDMCutLine(QGraphicsItem):
     def __init__(self, parent = None):
@@ -15,7 +18,20 @@ class QDMCutLine(QGraphicsItem):
         self.setZValue(2)
 
     def boundingRect(self):
-        return QRectF(0, 0, 1, 1)
+        return self.shape().boundingRect()
+
+    def shape(self):
+        poly = QPolygonF(self.line_points)
+
+        if len(self.line_points) > 1:
+            path = QPainterPath(self.line_points[0])
+            for pt in self.line_points[1:]:
+                path.lineTo(pt)
+        else:
+            path = QPainterPath(QPointF(0, 0))
+            path.lineTo(QPointF(1, 1))
+
+        return path
     
     def paint(self, painter: QPainter, QStyleOptionGraphicsItem, widget=None):
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)

--- a/node_editor/node_editor_window/graphics/graphics_edge.py
+++ b/node_editor/node_editor_window/graphics/graphics_edge.py
@@ -35,6 +35,12 @@ class QDMGraphicsEdge(QGraphicsPathItem):
     def setDestination(self, x: int, y: int):
         self.posDestination = [x, y]
 
+    def boundingRect(self):
+        return self.shape().boundingRect()
+    
+    def shape(self):
+        return self.calcPath()
+
     def paint(self, painter: QPainter, QStyleOptionGraphicsItem, widget = None):
         self.setPath(self.calcPath())
 
@@ -71,22 +77,23 @@ class QDMGraphicsEdgeBezier(QDMGraphicsEdge):
         cpy_s = 0
         cpy_d = 0
 
-        sspos = self.edge.start_socket.position
+        if self.edge.start_socket is not None:
+            sspos = self.edge.start_socket.position
 
-        if (s[0] > d[0] and sspos in (RIGHT_TOP, RIGHT_BOTTOM)) or (s[0] < d[0] and sspos in (LEFT_BOTTOM, LEFT_TOP)):
-            cpx_d *= -1
-            cpx_s *= -1
+            if (s[0] > d[0] and sspos in (RIGHT_TOP, RIGHT_BOTTOM)) or (s[0] < d[0] and sspos in (LEFT_BOTTOM, LEFT_TOP)):
+                cpx_d *= -1
+                cpx_s *= -1
 
-            cpy_d = (
-                (s[1] - d[1]) / math.fabs(
-                    (s[1] - d[1]) if (s[1] - d[1]) != 0 else 0.00001
-                )
-            ) * EDGE_CP_ROUNDNESS
-            cpy_s = (
-                (d[1] - s[1]) / math.fabs(
-                    (d[1] - s[1]) if (d[1] - s[1]) != 0 else 0.00001
-                )
-            ) * EDGE_CP_ROUNDNESS
+                cpy_d = (
+                    (s[1] - d[1]) / math.fabs(
+                        (s[1] - d[1]) if (s[1] - d[1]) != 0 else 0.00001
+                    )
+                ) * EDGE_CP_ROUNDNESS
+                cpy_s = (
+                    (d[1] - s[1]) / math.fabs(
+                        (d[1] - s[1]) if (d[1] - s[1]) != 0 else 0.00001
+                    )
+                ) * EDGE_CP_ROUNDNESS
 
         path = QPainterPath(QPointF(self.posSource[0], self.posSource[1]))
         path.cubicTo( s[0] + cpx_s, s[1] + cpy_s, d[0] + cpx_d, d[1] + cpy_d, self.posDestination[0], self.posDestination[1])

--- a/node_editor/node_editor_window/graphics/graphics_view.py
+++ b/node_editor/node_editor_window/graphics/graphics_view.py
@@ -31,6 +31,7 @@ class QDMGraphicsView(QGraphicsView):
 
         self.mode = MODE_NOOP
         self.editingFlag = False
+        self.rubberBandDragginRectangle = False
 
         self.zoomInFator = 1.25
         self.zoomClamp = False
@@ -145,6 +146,8 @@ class QDMGraphicsView(QGraphicsView):
                 )
                 QApplication.setOverrideCursor(Qt.CursorShape.CrossCursor)
                 return 
+            else:
+                self.rubberBandDragginRectangle = True
             
         super().mousePressEvent(event)
 
@@ -179,8 +182,9 @@ class QDMGraphicsView(QGraphicsView):
             self.mode = MODE_NOOP
             return 
         
-        if self.dragMode() == QGraphicsView.rubberBandChanged:
+        if self.rubberBandDragginRectangle:
             self.graphicsScene.scene.history.storeHistory("Selection changed")
+            self.rubberBandDragginRectangle = False
 
         super().mouseReleaseEvent(event)
 


### PR DESCRIPTION
## 🐞 Bugfix 24: Fix Edge Crashes and Improve Selection Stability

### Branch: `bugfixing/bugfixing-crashes-and-missing-edge`

---

### Summary

This PR addresses several **stability issues** related to edge rendering and mouse-based selection, particularly:

- Fixed crashes caused by missing edge shapes or bounding rects
- Corrected rubber band selection behavior to avoid unintended history triggers
- Updated version number to `v0.2.0.dev9`

---

### 📁 Files Modified

| File                          | Description                                                                 |
|-------------------------------|-----------------------------------------------------------------------------|
| `graphics/graphics_edge.py`   | Implemented `boundingRect()` and `shape()` to prevent drawing errors       |
| `graphics/graphics_cutline.py`| Refactored `boundingRect()` and `shape()` for proper QPainterPath geometry |
| `graphics/graphics_view.py`   | Added selection state tracking for rubber band interaction                 |
| `__init__.py`                 | Version bumped to `v0.2.0.dev9`                                            |

---

### ✅ Fix Highlights

#### 🔷 QDMGraphicsEdge – Bezier/Direct

- Added `boundingRect()`:
```python
def boundingRect(self):
    return self.shape().boundingRect()
```

- Added `shape()` using:
```python
def shape(self):
    return self.calcPath()
```

- Avoided `NoneType` error during edge control point calculation:
```python
if self.edge.start_socket is not None:
    sspos = self.edge.start_socket.position
    ...
```

#### 🔷 QDMCutLine

- Properly defined bounding area for rendering:
```python
def boundingRect(self):
    return self.shape().boundingRect()

def shape(self):
    if len(self.line_points) > 1:
        path = QPainterPath(self.line_points[0])
        for pt in self.line_points[1:]:
            path.lineTo(pt)
    else:
        path = QPainterPath(QPointF(0, 0))
        path.lineTo(QPointF(1, 1))
    return path
```

#### 🖱️ QDMGraphicsView – Selection Fix

- Added `rubberBandDragginRectangle` to track mouse press state
- Ensured history is stored **only** after rubber band selection:
```python
# On mouse press
self.rubberBandDragginRectangle = True

# On rubber band release
if self.rubberBandDragginRectangle:
    self.graphicsScene.scene.history.storeHistory("Selection changed")
    self.rubberBandDragginRectangle = False
```

---

### 🔧 Version Update

```python
__version__ = "0.2.0.dev9"
```

---

### 🧷 Related Commits

- Implemented `boundingRect` and `shape` in `QDMGraphicsEdge` and `QDMCutLine`
- Prevented control point calculation crash on missing socket
- Fixed incorrect selection event logging in `QDMGraphicsView`
- Updated project version to `v0.2.0.dev9`
