### PR TITLE
Feature/adding file has changed dialog

### DIFF
--- a/node_editor/node_editor_window/core/scene.py
+++ b/node_editor/node_editor_window/core/scene.py
@@ -18,6 +18,8 @@ class Scene(Serializable):
 
         self.scene_width = 64000
         self.scene_height = 64000
+        
+        self.has_been_modified = True
 
         self.initUI()
         self.history = SceneHistory(self)

--- a/node_editor/node_editor_window/core/scene_clipboard.py
+++ b/node_editor/node_editor_window/core/scene_clipboard.py
@@ -56,7 +56,7 @@ class SceneClipboard():
         # if CUT(aka deleted) remove selected items
         if delete:
             self.scene.graphicsScene.views()[0].deleteSelected()
-            self.scene.history.storeHistory("Cut out elements from scene")
+            self.scene.history.storeHistory("Cut out elements from scene", setModified=True)
 
         return data
     
@@ -99,8 +99,5 @@ class SceneClipboard():
                 new_edge = Edge(self.scene)
                 new_edge.deserialize(edge_data, hashmap, restore_id=False)
 
-        # create each sockets
-
         # store history
-
-        logger.debug("deserialization from clipboard, data:\n%s", pformat(data))
+        self.scene.history.storeHistory("Pasted elements in scene", setModified=True)

--- a/node_editor/node_editor_window/core/scene_history.py
+++ b/node_editor/node_editor_window/core/scene_history.py
@@ -29,7 +29,10 @@ class SceneHistory():
         logger.debug(f"Restoring history ... current step: {self.history_current_step} {len(self.history_stack)}")
         self.restoreHistoryStamp(self.history_stack[self.history_current_step])
 
-    def storeHistory(self, desc):
+    def storeHistory(self, desc, setModified: bool = False):
+        if setModified:
+            self.scene.has_been_modified = True
+
         logger.debug(f"Storing history ... current step: {self.history_current_step} {len(self.history_stack)}")
         hs = self.createHistoryStamp(desc)
 

--- a/node_editor/node_editor_window/graphics/graphics_node.py
+++ b/node_editor/node_editor_window/graphics/graphics_node.py
@@ -48,7 +48,7 @@ class QDMGraphicsNode(QGraphicsItem):
 
         if self.wasMoved:
             self.wasMoved = False
-            self.node.scene.history.storeHistory("Node moved")
+            self.node.scene.history.storeHistory("Node moved", setModified=True)
 
     @property
     def title(self): return self._title

--- a/node_editor/node_editor_window/graphics/graphics_view.py
+++ b/node_editor/node_editor_window/graphics/graphics_view.py
@@ -262,7 +262,7 @@ class QDMGraphicsView(QGraphicsView):
                 if edge.graphicsEdge.intersectsWith(p1, p2):
                     edge.remove()
 
-        self.graphicsScene.scene.history.storeHistory("Delete cutted edges")
+        self.graphicsScene.scene.history.storeHistory("Delete cutted edges", setModified=True)
 
     def deleteSelected(self):
         for item in self.graphicsScene.selectedItems():
@@ -271,7 +271,7 @@ class QDMGraphicsView(QGraphicsView):
             elif hasattr(item, "node"):
                 item.node.remove()
 
-        self.graphicsScene.scene.history.storeHistory("Delete selected")
+        self.graphicsScene.scene.history.storeHistory("Delete selected", setModified=True)
 
     def debug_modifiers(self, event):
         out = "KEYS: "
@@ -313,7 +313,7 @@ class QDMGraphicsView(QGraphicsView):
                 logger.debug(f"    reassigned start and end sockets to drag edge")
                 self.dragEdge.updatePositions()
                 # store history
-                self.graphicsScene.scene.history.storeHistory("Create new edge by dragging")
+                self.graphicsScene.scene.history.storeHistory("Create new edge by dragging", setModified=True)
                 return True
         
         logger.debug("End dragging edge")


### PR DESCRIPTION
## 💾 Feature 25: Scene Modification Tracking and Save Confirmation

### Summary

This PR introduces a robust system for tracking **scene modification status** and prompting users before closing or replacing unsaved work. It also refactors the history and window title update logic to clearly reflect the scene’s state. Additionally, this PR **prepares the foundation** for future autosave or recovery features.

---

### 📁 Files Modified

| File                           | Description                                                                 |
|--------------------------------|-----------------------------------------------------------------------------|
| `node_editor_window.py`        | Added close event handling, `maybeSave()` logic, and dynamic title updates |
| `scene.py`                     | Introduced modification tracking with listeners                            |
| `scene_history.py`             | Extended `storeHistory()` with `setModified` parameter                     |
| `graphics_view.py`             | Updated history calls for cut/delete operations to trigger modified state  |
| `graphics_node.py`             | Node move history now flags scene as modified                              |
| `scene_clipboard.py`          | Clipboard cut action now flags scene as modified                           |

---

### ✅ Feature Highlights

#### 🔐 Save Confirmation Prompt
Users are now prompted when trying to:
- Close the window
- Create a new scene
- Open another file

```python
def maybeSave(self):
    if not self.isModified():
        return True

    res = QMessageBox.warning(
        self,
        self.tr("About to lose your work?"),
        self.tr("The document has been modified.\nDo you want to save your changes?"),
        QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel
    )

    if res == QMessageBox.Save:
        return self.onFileSave()
    elif res == QMessageBox.Cancel:
        return False

    return True
```

---

#### 🖊️ Scene Modification Detection
Each meaningful edit (cut, delete, move, etc.) now updates the `scene.has_been_modified` flag and notifies registered UI listeners (like the window title).

**New property in `Scene`:**
```python
@property
def has_been_modified(self)
@has_been_modified.setter
def has_been_modified(self, value)
```

**Change title on modify:**
```python
scene.addHasBeenModifiedListener(self.changeTitle)
```

---

#### 📝 File Operations Improvements
- Refactored `onFileSave()`, `onFileSaveAs()` to return success status
- File dialog flow in `onFileOpen()` wrapped with `maybeSave()`
- Filename and modified status correctly reset upon save/load

---

#### 📌 History System Update

History actions now support marking the scene as modified:

```python
def storeHistory(self, desc, setModified=False):
    ...
    if setModified:
        self.scene.has_been_modified = True
```

Applied to:
- `deleteSelected()`
- `cutIntersectingEdges()`
- `mouseReleaseEvent()` on moved nodes
- Clipboard `Cut` action

---

> [!WARNING]
> ### ❗Known Issue #36 
> 
> - **Bug:** After saving, the `*` symbol in the title does not disappear as expected  
> - **Severity:** Functionality unaffected, but UX is significantly impacted  
> - **Next Steps:** Will be addressed in a future PR with more advanced state syncing between `Scene` and `Window`

---

### 🧠 Related Commits

- Added scene modification state detection and window title sync
- Wrapped destructive file operations with `maybeSave()` checks
- Adjusted history system to optionally flag modified state
