### PR TITLE
Refactor/finishing refactoring open save save as

### DIFF
--- a/src/node_editor_calculator/calc_window.py
+++ b/src/node_editor_calculator/calc_window.py
@@ -55,22 +55,6 @@ class CalculatorWindow(NodeEditorWindow):
             self.writeSettings()
             event.accept()
 
-    def updateMenus(self):
-        logger.info("Update Menus")
-        active = self.activeMdiChild()
-        hasMdiChild = (active is not None)
-
-        self.actSave.setEnabled(hasMdiChild)
-        self.actSaveAs.setEnabled(hasMdiChild)
-        self.actClose.setEnabled(hasMdiChild)
-        self.actCloseAll.setEnabled(hasMdiChild)
-        self.actTile.setEnabled(hasMdiChild)
-        self.actCascade.setEnabled(hasMdiChild)
-        self.actNext.setEnabled(hasMdiChild)
-        self.actPrevious.setEnabled(hasMdiChild)
-        self.actSeparator.setVisible(hasMdiChild)
-
-
     def createActions(self):
         super().createActions()
 
@@ -85,6 +69,13 @@ class CalculatorWindow(NodeEditorWindow):
 
         self.actAbout = QAction("&About", self, statusTip="Show the application's About box", triggered=self.about)
 
+    def getCurrentNodeEditorWidget(self):
+        """ we're returning NodeEditorWidget here... """
+        activeSubWindow = self.mdiArea.activeSubWindow()
+        if activeSubWindow:
+            return activeSubWindow.widget()
+        return None
+
     def onFileNew(self):
         try:
             subwnd = self.createMdiChild()
@@ -92,28 +83,28 @@ class CalculatorWindow(NodeEditorWindow):
             subwnd.show()
         except Exception as e: logger.error(e)
 
-    def onFileSave(self):
-        current_nodeeditor = self.activeMdiChild()
-        if current_nodeeditor:
-            if not current_nodeeditor.isFilenameSet():
-                return self.onFileSaveAs()
-            else:
-                current_nodeeditor.fileSave() # we don't pass argument, keep the filename
-                self.statusBar().showMessage("Succesfully saved %s" % current_nodeeditor.filename, 5000)
-                current_nodeeditor.setTitle()
-                return True
+    # def onFileSave(self):
+    #     current_nodeeditor = self.activeMdiChild()
+    #     if current_nodeeditor:
+    #         if not current_nodeeditor.isFilenameSet():
+    #             return self.onFileSaveAs()
+    #         else:
+    #             current_nodeeditor.fileSave() # we don't pass argument, keep the filename
+    #             self.statusBar().showMessage("Succesfully saved %s" % current_nodeeditor.filename, 5000)
+    #             current_nodeeditor.setTitle()
+    #             return True
 
-    def onFileSaveAs(self):
-        current_nodeeditor = self.activeMdiChild()
-        if current_nodeeditor:
-            fname, filter = QFileDialog.getSaveFileName(self, "Save graph file")
+    # def onFileSaveAs(self):
+    #     current_nodeeditor = self.activeMdiChild()
+    #     if current_nodeeditor:
+    #         fname, filter = QFileDialog.getSaveFileName(self, "Save graph file")
 
-            if fname == '': return False
+    #         if fname == '': return False
 
-            current_nodeeditor.fileSave(fname)
-            current_nodeeditor.setTitle()
-            self.statusBar().showMessage("Successfully saved as %s" % fname, 5000)
-            return True
+    #         current_nodeeditor.fileSave(fname)
+    #         current_nodeeditor.setTitle()
+    #         self.statusBar().showMessage("Successfully saved as %s" % fname, 5000)
+    #         return True
 
     def onFileOpen(self):
         fnames, filter = QFileDialog.getOpenFileNames(self, 'Open graph from file')
@@ -155,6 +146,21 @@ class CalculatorWindow(NodeEditorWindow):
         self.helpMenu = self.menuBar().addMenu("&Help")
         self.helpMenu.addAction(self.actAbout)
 
+    def updateMenus(self):
+        logger.info("Update Menus")
+        active = self.getCurrentNodeEditorWidget()
+        hasMdiChild = (active is not None)
+
+        self.actSave.setEnabled(hasMdiChild)
+        self.actSaveAs.setEnabled(hasMdiChild)
+        self.actClose.setEnabled(hasMdiChild)
+        self.actCloseAll.setEnabled(hasMdiChild)
+        self.actTile.setEnabled(hasMdiChild)
+        self.actCascade.setEnabled(hasMdiChild)
+        self.actNext.setEnabled(hasMdiChild)
+        self.actPrevious.setEnabled(hasMdiChild)
+        self.actSeparator.setVisible(hasMdiChild)
+
     def updateWindowMenu(self):
         self.windowMenu.clear()
         self.windowMenu.addAction(self.actClose)
@@ -182,7 +188,7 @@ class CalculatorWindow(NodeEditorWindow):
 
             action = self.windowMenu.addAction(text)
             action.setCheckable(True)
-            action.setChecked(child is self.activeMdiChild())
+            action.setChecked(child is self.getCurrentNodeEditorWidget())
             action.triggered.connect(self.windowMapper.map)
             self.windowMapper.setMapping(action, window)    
 
@@ -216,12 +222,12 @@ class CalculatorWindow(NodeEditorWindow):
                 return window
         return None
 
-    def activeMdiChild(self):
-        """ we're returning NodeEditorWidget here... """
-        activeSubWindow = self.mdiArea.activeSubWindow()
-        if activeSubWindow:
-            return activeSubWindow.widget()
-        return None
+    # def activeMdiChild(self):
+    #     """ we're returning NodeEditorWidget here... """
+    #     activeSubWindow = self.mdiArea.activeSubWindow()
+    #     if activeSubWindow:
+    #         return activeSubWindow.widget()
+    #     return None
 
     def setActiveSubWindow(self, window):
         if window:

--- a/src/node_editor_window/qss/nodeeditor-dark.qss
+++ b/src/node_editor_window/qss/nodeeditor-dark.qss
@@ -95,7 +95,7 @@ QMdiArea QTabBar QToolButton::right-arrow {
 
 QMdiArea QTabBar::close-button:selected {
     image: url(":icons/tab_close_btn.png");
-    origin: border;
+    /* origin: border; */
     subcontrol-origin: border;
     subcontrol-position: right bottom;
 }
@@ -104,7 +104,7 @@ QMdiArea QTabBar::close-button:!selected {
 }
 
 QMdiSubWindow {
-    border-size: 1px;
+    /* border-size: 1px; */
     border-style: solid;
     background: #616161;
 }

--- a/src/node_editor_window/ui/node_editor_window.py
+++ b/src/node_editor_window/ui/node_editor_window.py
@@ -128,18 +128,30 @@ class NodeEditorWindow(QMainWindow):
                 self.setTitle()
 
     def onFileSave(self):
-        if self.getCurrentNodeEditorWidget().filename is None: return self.onFileSaveAs()
-        self.getCurrentNodeEditorWidget().fileSave()
-        self.statusBar().showMessage("Successfully saved %s" % self.getCurrentNodeEditorWidget().filename)
-        self.setTitle()
+        current_nodeeditor = self.getCurrentNodeEditorWidget()
+        if current_nodeeditor is not None:
+            if not current_nodeeditor.isFilenameSet(): return self.onFileSaveAs()
+
+            current_nodeeditor.fileSave()
+            self.statusBar().showMessage("Successfully saved %s" % current_nodeeditor.filename, 5000)
+
+            # support for MDI app
+            if hasattr(current_nodeeditor, "setTitle"): current_nodeeditor.setTitle()
+            else: self.setTitle()
         return True
 
     def onFileSaveAs(self):
-        fname, filter = QFileDialog.getSaveFileName(self, self.tr("Save graph to file"))
-        if fname == '': return False
-        self.getCurrentNodeEditorWidget().fileSave(fname)
-        self.statusBar().showMessage("Successfully saved as %s" % self.getCurrentNodeEditorWidget().filename)
-        self.setTitle()
+        current_nodeeditor = self.getCurrentNodeEditorWidget()
+        if current_nodeeditor is not None:
+            fname, filter = QFileDialog.getSaveFileName(self, self.tr("Save graph to file"))
+            if fname == '': return False
+
+            current_nodeeditor.fileSave(fname)
+            self.statusBar().showMessage("Successfully saved as %s" % current_nodeeditor.filename, 5000)
+
+            # support for MDI app
+            if hasattr(current_nodeeditor, "setTitle"): current_nodeeditor.setTitle()
+            else: self.setTitle()
         return True
 
     def onEditUndo(self):


### PR DESCRIPTION
## 💾 Feature 33: Refactor File Saving for MDI Support & UI Style Fixes

### Summary

This PR refactors the **file saving workflow** to better support **MDI (Multiple Document Interface) applications**, ensuring proper title updates and menu state management.  
It also removes unsupported QSS properties in `nodeeditor_dark.qss` to prevent **unknown property warnings** during stylesheet loading.  

Additionally, this PR **resolves Issue #36** : *Window Title does not clear asterisk after save*.

---

### 📁 Files Modified

| File                                | Description                                                                 |
|------------------------------------|-----------------------------------------------------------------------------|
| `node_editor_window/calc_window.py` | Added `getCurrentNodeEditorWidget()` and refactored MDI file saving handling |
| `node_editor_window/node_editor_window.py` | Improved `onFileSave` & `onFileSaveAs` for better MDI compatibility |
| `node_editor_window/qss/nodeeditor_dark.qss` | Removed invalid `border-origin` and commented out unsupported `border-size` |
| `node_editor_window/calc_window.py` | Updated `updateWindowMenu()` to use new MDI-aware logic |

---

### ✅ Feature Highlights

#### 🔐 Improved File Saving for MDI Applications

Replaced legacy `activeMdiChild()` usage with a more **consistent MDI-aware widget accessor**:

```python
def getCurrentNodeEditorWidget(self):
    activeSubWindow = self.mdiArea.activeSubWindow()
    if activeSubWindow:
        return activeSubWindow.widget()
    return None
```

Refactored onFileSave & onFileSaveAs to:

* Support both standalone and MDI mode
* Dynamically detect if setTitle() exists for the current editor
* Properly update window title after saving
* Fix the issue where the * (unsaved indicator) was not cleared after saving

```python
def onFileSave(self):
    current_nodeeditor = self.getCurrentNodeEditorWidget()
    if current_nodeeditor is not None:
        if not current_nodeeditor.isFilenameSet():
            return self.onFileSaveAs()

        current_nodeeditor.fileSave()
        self.statusBar().showMessage("Successfully saved %s" % current_nodeeditor.filename, 5000)

        # support for MDI app
        if hasattr(current_nodeeditor, "setTitle"): current_nodeeditor.setTitle()
        else: self.setTitle()
    return True
```

✅ Issue #36 (Window Title does not clear asterisk after save) → Resolved 🎉

---

### 🖊️ Menu Update Logic Refinement

Updated `updateWindowMenu()` to correctly reflect active MDI child state:
```python
action.setChecked(child is self.getCurrentNodeEditorWidget())
```

This ensures the active window menu item accurately highlights the current MDI child.

---

### 📝 QSS Style Fixes
Fixed QSS warnings by:

* Removing `origin: border;` from `QTabBar::close-button:selected`, which caused invalid property errors.
* Commenting out border-size for `QMdiSubWindow`, avoiding unknown property prompts during stylesheet parsing.
These changes improve Qt stylesheet compatibility and reduce noise in the debug log.

---

### 🧠 Related Commits

* Added `getCurrentNodeEditorWidget()` for better MDI child access
* Refactored `onFileSave` & `onFileSaveAs` for unified MDI support
* Fixed Issue #36 (window title asterisk now clears after saving)
* Removed unsupported QSS properties to eliminate style warnings
* Updated menu logic in `updateWindowMenu()` for accurate active state

Issue #36 → Closed
