### PR TITLE
Feature/Centralized Selection State Management and History Integration

### DIFF
--- a/src/node_editor_window/core/scene.py
+++ b/src/node_editor_window/core/scene.py
@@ -24,6 +24,7 @@ class Scene(Serializable):
 
         self._has_been_modified = False
         self._has_been_modified_listeners = []
+        self._last_selected_items = []
         self._item_selected_listeners = []
         self._items_deselected_listeners = []
 
@@ -39,10 +40,18 @@ class Scene(Serializable):
         self.graphicsScene.setGraphicsScene(self.scene_width, self.scene_height)
 
     def onItemSelected(self):
-        logger.info(" ~onItemSelected")
+        current_selected_items = self.getSelectedItems()
+        if current_selected_items != self._last_selected_items:
+            self._last_selected_items = current_selected_items
+            self.history.storeHistory("Selection Changed")
+            for callback in self._item_selected_listeners: callback()
 
     def onItemsDeselected(self):
-        logger.info(" ~onItemsDeselected")
+        self.resetLastSelectedStates()
+        if self._last_selected_items != []:
+            self._last_selected_items = []
+            self.history.storeHistory("Deselected Everything")
+            for callback in self._items_deselected_listeners: callback()
 
     def isModified(self):
         return self.has_been_modified
@@ -59,8 +68,7 @@ class Scene(Serializable):
             self._has_been_modified = value
 
             # call all registered listeners
-            for callback in self._has_been_modified_listeners:
-                callback()
+            for callback in self._has_been_modified_listeners: callback()
 
         self._has_been_modified = value
 

--- a/src/node_editor_window/core/scene.py
+++ b/src/node_editor_window/core/scene.py
@@ -24,10 +24,25 @@ class Scene(Serializable):
 
         self._has_been_modified = False
         self._has_been_modified_listeners = []
+        self._item_selected_listeners = []
+        self._items_deselected_listeners = []
 
         self.initUI()
         self.history = SceneHistory(self)
         self.clipboard = SceneClipboard(self)
+
+        self.graphicsScene.itemSelected.connect(self.onItemSelected)
+        self.graphicsScene.itemsDeselected.connect(self.onItemsDeselected)
+
+    def initUI(self):
+        self.graphicsScene = QDMGraphicsScene(self)
+        self.graphicsScene.setGraphicsScene(self.scene_width, self.scene_height)
+
+    def onItemSelected(self):
+        logger.info(" ~onItemSelected")
+
+    def onItemsDeselected(self):
+        logger.info(" ~onItemsDeselected")
 
     def isModified(self):
         return self.has_been_modified
@@ -52,9 +67,19 @@ class Scene(Serializable):
     def addHasBeenModifiedListener(self, callback):
         self._has_been_modified_listeners.append(callback)
 
-    def initUI(self):
-        self.graphicsScene = QDMGraphicsScene(self)
-        self.graphicsScene.setGraphicsScene(self.scene_width, self.scene_height)
+    def addItemSelectedListener(self, callback):
+        self._item_selected_listeners.append(callback)
+
+    def addItemsDeselectedListener(self, callback):
+        self._items_deselected_listeners.append(callback)
+
+    # custom flag to detect node or edge has been selected....
+    def resetLastSelectedStates(self):
+        for node in self.nodes:
+            node.graphicsNode._last_selected_state = False
+        for edge in self.edges:
+            edge.graphicsEdge._last_selected_state = False
+
 
     def addNode(self, node):
         self.nodes.append(node)

--- a/src/node_editor_window/graphics/graphics_edge.py
+++ b/src/node_editor_window/graphics/graphics_edge.py
@@ -12,6 +12,17 @@ class QDMGraphicsEdge(QGraphicsPathItem):
         super().__init__(parent)
         self.edge = edge
 
+        self.posSource = [0, 0]
+        self.posDestination = [200, 100]
+
+        self.initAssets()
+        self.initUI()
+
+    def initUI(self):
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable)
+        self.setZValue(-1) 
+
+    def initAssets(self):
         self._color = QColor("#001000")
         self._color_selected = QColor("#00FF00")
         self._pen = QPen(self._color)
@@ -22,12 +33,15 @@ class QDMGraphicsEdge(QGraphicsPathItem):
         self._pen_selected.setWidthF(2)
         self._pen_dragging.setWidthF(2)
 
-        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable)
+    def onSelected(self):
+        self.edge.scene.graphicsScene.itemSelected.emit()
 
-        self.setZValue(-1) 
-
-        self.posSource = [0, 0]
-        self.posDestination = [200, 100]
+    def mouseReleaseEvents(self, event):
+        super().mouseReleaseEvent(event)
+        if self._last_selected_state != self.isSelected():
+            self.edge.scene.resetLastSelectedStates()
+            self._last_selected_state = self.isSelected()
+            self.onSelected()
 
     def setSource(self, x: int, y: int):
         self.posSource = [x, y]

--- a/src/node_editor_window/graphics/graphics_node.py
+++ b/src/node_editor_window/graphics/graphics_node.py
@@ -62,7 +62,15 @@ class QDMGraphicsNode(QGraphicsItem):
             self._was_moved = False
             self.node.scene.history.storeHistory("Node moved", setModified=True)
 
-        if self._last_selected_state != self.isSelected():
+            self.node.scene.resetLastSelectedStates()
+            self._last_selected_state = True
+
+            # we need to store the last selected state, because moving does also select the nodes
+            self.node.scene._last_selected_items = self.node.scene.getSelectedItems()
+            return
+
+        # handle when grNode was clicked on
+        if self._last_selected_state != self.isSelected() or self.node.scene._last_selected_items != self.node.scene.getSelectedItems():
             self.node.scene.resetLastSelectedStates()
             self._last_selected_state = self.isSelected()
             self.onSelected()

--- a/src/node_editor_window/graphics/graphics_node.py
+++ b/src/node_editor_window/graphics/graphics_node.py
@@ -11,29 +11,41 @@ class QDMGraphicsNode(QGraphicsItem):
         self._title_color = Qt.GlobalColor.white
         self._title_font = QFont("Arial")
 
+        self._was_moved = False
+        self._last_selected_state = False
+
+        self.initSizes()
+        self.initAssets()
+        self.initUI()
+
+    def initUI(self):
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable)
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable)
+
+        self.initTitle()
+        self.title = self.node.title
+        self.initSockets()
+        self.initContent()
+
+    def initSizes(self):
         self.width = 180
         self.height = 240
         self.edge_size = 10.0
         self.title_height = 24
         self._padding = 4.0
 
+    def initAssets(self):
+        self._title_color = Qt.GlobalColor.white
+        self._title_font = QFont("Ubuntu", 10)
+
         self._pen_default = QPen(QColor("#7F000000"))
         self._pen_selected = QPen(QColor("#FFFFA637"))
         self._brush_title = QBrush(QColor("#FF313131"))
         self._brush_background = QBrush(QColor("#E3212121"))
 
-        # init title
-        self.initTitle()
-        self.title = self.node.title
-
-        # init sockets
-        self.initSockets()
-
-        # init content
-        self.initContent()
-
-        self.initUI()
-        self.wasMoved = False
+    def onSelected(self):
+        # print("grNode onSelected")
+        self.node.scene.graphicsScene.itemSelected.emit()
 
     def mouseMoveEvent(self, event):
         super().mouseMoveEvent(event)
@@ -41,14 +53,19 @@ class QDMGraphicsNode(QGraphicsItem):
         for node in self.scene().scene.nodes:
             if node.graphicsNode.isSelected():
                 node.updateConnectedEdges()
-        self.wasMoved = True
+        self._was_moved = True
 
     def mouseReleaseEvent(self, event):
         super().mouseReleaseEvent(event)
 
-        if self.wasMoved:
-            self.wasMoved = False
+        if self._was_moved:
+            self._was_moved = False
             self.node.scene.history.storeHistory("Node moved", setModified=True)
+
+        if self._last_selected_state != self.isSelected():
+            self.node.scene.resetLastSelectedStates()
+            self._last_selected_state = self.isSelected()
+            self.onSelected()
 
     @property
     def title(self): return self._title
@@ -59,10 +76,6 @@ class QDMGraphicsNode(QGraphicsItem):
 
     def boundingRect(self):
         return QRectF(0, 0, self.width, self.height).normalized()
-
-    def initUI(self):
-        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable)
-        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable)
 
     def initTitle(self):
         self.title_item = QGraphicsTextItem(self)

--- a/src/node_editor_window/graphics/graphics_scene.py
+++ b/src/node_editor_window/graphics/graphics_scene.py
@@ -1,12 +1,14 @@
 import math
-from PyQt5.QtCore import QLine
+from PyQt5.QtCore import QLine, pyqtSignal
 from PyQt5.QtGui import QColor, QPen, QPainter
 from PyQt5.QtWidgets import QGraphicsScene
 
 class QDMGraphicsScene(QGraphicsScene):
+    itemSelected = pyqtSignal()
+    itemsDeselected = pyqtSignal()
+
     def __init__(self, scene, parent=None):
         super().__init__(parent)
-
         self.scene = scene
 
         self.gridSize = 20

--- a/src/node_editor_window/graphics/graphics_view.py
+++ b/src/node_editor_window/graphics/graphics_view.py
@@ -184,8 +184,8 @@ class QDMGraphicsView(QGraphicsView):
             return 
         
         if self.rubberBandDragginRectangle:
-            self.graphicsScene.scene.history.storeHistory("Selection changed")
             self.rubberBandDragginRectangle = False
+            self.graphicsScene.scene.history.storeHistory("Selection changed")
 
         super().mouseReleaseEvent(event)
 

--- a/src/node_editor_window/graphics/graphics_view.py
+++ b/src/node_editor_window/graphics/graphics_view.py
@@ -185,7 +185,19 @@ class QDMGraphicsView(QGraphicsView):
         
         if self.rubberBandDragginRectangle:
             self.rubberBandDragginRectangle = False
-            self.graphicsScene.scene.history.storeHistory("Selection changed")
+            current_selected_items = self.graphicsScene.selectedItems()
+
+            if current_selected_items != self.graphicsScene.scene._last_selected_items:
+                if current_selected_items == []:
+                    self.graphicsScene.itemsDeselected.emit()
+                else:
+                    self.graphicsScene.itemSelected.emit()
+                self.graphicsScene.scene._last_selected_items = current_selected_items
+            return
+
+        # otherwise deselect everything
+        if item is None:
+            self.graphicsScene.itemsDeselected.emit()
 
         super().mouseReleaseEvent(event)
 


### PR DESCRIPTION
## 🚀 Feature 35、36 : Centralized Selection State Management and History Integration

### Summary
This PR enhances the selection and deselection logic for nodes and edges within the scene. It introduces centralized state tracking (`_last_selected_items`) to prevent redundant history entries, and ensures that item selection changes trigger appropriate signals and callbacks. The refactor improves UX consistency and makes it easier to extend future features like property panels or context-based UI updates.

---

### 📁 Files Modified

| File Path                           | Description                                                             |
|------------------------------------|-------------------------------------------------------------------------|
| `scene.py`                         | Added `_last_selected_items` and improved item selection signal logic   |
| `graphics_edge.py`                 | Synced selection tracking with scene and updated comparison logic       |
| `graphics_node.py`                 | Synced selection tracking with scene and updated comparison logic       |
| `graphics_scene.py`                | Declared `itemSelected` and `itemsDeselected` signals                   |
| `graphics_view.py`                 | Enhanced rubber band logic and refined deselection behavior             |

---

### ✅ Feature Highlights

- 🧠 **Scene-Level Selection Tracking**
  - `scene.py`:
    ```python
    self._last_selected_items = []
    ```
  - Prevents redundant `storeHistory()` calls by comparing current and last selected items.

- 📤 **Centralized Signal Emission**
  - `scene.py`:
    ```python
    def onItemSelected(self):
        current_selected_items = self.getSelectedItems()
        if current_selected_items != self._last_selected_items:
            self._last_selected_items = current_selected_items
            self.history.storeHistory("Selection Changed")
            for callback in self._item_selected_listeners: callback()

    def onItemsDeselected(self):
        self.resetLastSelectedStates()
        if self._last_selected_items != []:
            self._last_selected_items = []
            self.history.storeHistory("Deselected Everything")
            for callback in self._items_deselected_listeners: callback()
    ```

- 🧩 **Updated Selection Logic in Graphics Items**
  - `graphics_node.py` / `graphics_edge.py`:
    ```python
    if self._last_selected_state != self.isSelected() or \
       self.node.scene._last_selected_items != self.node.scene.getSelectedItems():
        self.node.scene.itemSelected.emit()
    ```

  - After mouse release:
    ```python
    self.node.scene.resetLastSelectedStates()
    self._last_selected_state = True
    self.node.scene._last_selected_items = self.node.scene.getSelectedItems()
    ```

- 📦 **Improved Rubber Band Handling**
  - `graphics_view.py`:
    ```python
    if self.rubberBandDragginRectangle:
        self.rubberBandDragginRectangle = False
        current_selected_items = self.graphicsScene.selectedItems()

        if current_selected_items != self.graphicsScene.scene._last_selected_items:
            if current_selected_items == []:
                self.graphicsScene.itemsDeselected.emit()
            else:
                self.graphicsScene.itemSelected.emit()
            self.graphicsScene.scene._last_selected_items = current_selected_items
        return

    if item is None:
        self.graphicsScene.itemsDeselected.emit()
    ```

---

### 📌 Smart History Triggers

```python
# scene.py
self.history.storeHistory("Selection Changed")
self.history.storeHistory("Deselected Everything")

# graphics_view.py
if self.rubberBandDragginRectangle:
    self.graphicsScene.scene.history.storeHistory("Selection changed")
```

---

### 🧠 Implementation Notes

- Uses `_last_selected_items` to avoid duplicated selection events and history entries.
- Signals now only emit when actual selection change occurs.
- Ensures rubber band and manual deselections are handled consistently.
- Keeps selection logic centralized in `scene.py`, improving maintainability.

---

### 🧷 Related Commits

- `Added selection and deselection status management, and optimized history storage logic`
- `Refactored mouseReleaseEvent for both GraphicsNode and GraphicsEdge`
- `Improved rubber band selection flow and deselection fallback logic`
